### PR TITLE
Enable running unsigned code

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -9,6 +9,10 @@ add_definitions("-DSOURCE_PATH_SIZE=${SOURCE_PATH_SIZE}")
 
 if ($ENV{TARGET} MATCHES "nCipher")
   include(codesafe.cmake)
+
+  if ($ENV{UNSIGNED} MATCHES "yes")
+     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DUNSIGNED")
+  endif ()
 endif ()
 
 add_subdirectory(trezor-crypto)
@@ -20,9 +24,9 @@ include_directories(include nanopb trezor-crypto "${CMAKE_BINARY_DIR}/proto")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror -Wno-unknown-pragmas")
 
 if ($ENV{CURRENCY} MATCHES "btc-testnet")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DBTC_TESTNET -Werror -Wno-unknown-pragmas")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DBTC_TESTNET")
 elseif ($ENV{CURRENCY} MATCHES "btc-mainnet")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DBTC_MAINNET -Werror -Wno-unknown-pragmas")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DBTC_MAINNET")
 endif ()
 
 set(main_SRC

--- a/core/codesafe.cmake
+++ b/core/codesafe.cmake
@@ -28,14 +28,29 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mpowerpc -mcpu=e5500 -mno-toc -mbig-endian 
 set(CMAKE_C_LINK_EXECUTABLE
     "${CODESAFE_GCC} -Wl,-wrap=read -Wl,-wrap=write -Wl,-wrap=socket -Wl,-wrap=send  -Wl,-wrap=sendto -Wl,-wrap=recv -Wl,-wrap=recvfrom -Wl,-wrap=listen -Wl,-wrap=connect -Wl,-wrap=bind -Wl,-wrap=setsockopt -Wl,-wrap=select -Wl,-wrap=accept -Wl,-wrap=poll -Bstatic -o <TARGET> <OBJECTS> <LINK_LIBRARIES> ${NFAST_PATH}/c/csd/lib-ppc-linux-gcc/hoststdioeinetsocks.o ${NFAST_PATH}/c/csd/lib-ppc-linux-gcc/libfaksys.a ${NFAST_PATH}/c/csd/lib-ppc-linux-gcc/libcutils.a ${NFAST_PATH}/c/csd/lib-ppc-linux-gcc/libvfsextras.a ${NFAST_PATH}/c/csd/lib-ppc-linux-gcc/libseewrpr.a ${NFAST_PATH}/c/csd/lib-ppc-linux-gcc/libipccore.a ${NFAST_PATH}/c/csd/lib-ppc-linux-gcc/libsolotrace.a ${NFAST_PATH}/c/csd/lib-ppc-linux-gcc/libnfstub.a ${NFAST_PATH}/c/csd/lib-ppc-linux-gcc/libfaksys.a ${NFAST_PATH}/c/csd/lib-ppc-linux-gcc/libseewrpr.a ${NFAST_PATH}/c/csd/lib-ppc-linux-gcc/seelib.a ${NFAST_PATH}/c/csd/lib-ppc-linux-gcc/libipccore.a -lpthread -lrt")
 
+add_custom_command(OUTPUT subzero-unsigned.ar
+  DEPENDS subzero
+  COMMAND ${NFAST_PATH}/bin/tct2 --pack --infile=subzero --outfile subzero-unsigned.ar
+)
+
+add_custom_command(OUTPUT subzero.cpio
+  COMMAND echo dummy > dummy
+  COMMAND ${NFAST_PATH}/bin/cpioc subzero.cpio dummy
+)
+
+add_custom_target(run-unsigned
+  DEPENDS subzero-unsigned.ar subzero.cpio
+  COMMAND sudo ${NFAST_PATH}/bin/nopclearfail -c -a
+  COMMAND sudo ${NFAST_PATH}/bin/see-stdioesock-serv --machine subzero-unsigned.ar --userdata-raw subzero.cpio
+)
+
 add_custom_command(OUTPUT subzero-signed.sar
   DEPENDS subzero
   COMMAND ${NFAST_PATH}/bin/tct2 --sign-and-pack --key=subzerosigner --is-machine --machine-type=PowerPCELF --infile=subzero --outfile subzero-signed.sar
 )
 
 add_custom_command(OUTPUT subzero-userdata-signed.sar
-  COMMAND echo dummy > dummy
-  COMMAND ${NFAST_PATH}/bin/cpioc subzero.cpio dummy
+  DEPENDS subzero.cpio
   COMMAND ${NFAST_PATH}/bin/tct2 --sign-and-pack --key=subzerodatasigner --machine-key-ident=subzerosigner --infile=subzero.cpio --outfile subzero-userdata-signed.sar
 )
 

--- a/core/src/ncipher/module_certificate.c
+++ b/core/src/ncipher/module_certificate.c
@@ -42,6 +42,9 @@ Result module_certificate_init(M_CertificateList *cert_list, M_Certificate *cert
   INFO("Got %d signers", signer_count);
   if (signer_count == 0) {
     NFastApp_Free_Reply(app, NULL, NULL, &reply);
+#ifdef UNSIGNED
+    return Result_SUCCESS;
+#endif
     return Result_GET_MODULE_CERTIFICATE_NO_SIGNERS;
   }
 


### PR DESCRIPTION
In dev, with a HSM, it's sometimes useful to be able to run unsigned
code. It avoids having to setup all the keys, etc.