### PR TITLE
Specify dist for Travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+dist: trusty
 
 jdk:
   - oraclejdk8


### PR DESCRIPTION
I'm seeing some build failures without this option. There some context
here: https://travis-ci.community/t/oracle-jdk-11-and-10-are-pre-installed-not-the-openjdk-builds/785/14