### PR TITLE
Refactor no_rollback

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -36,6 +36,7 @@ set(main_SRC
     "src/init_wallet.c"
     "src/memzero.c"
     "src/nanopb_stream.c"
+    "src/no_rollback.c"
     "src/print.c"
     "src/rpc.c"
     "src/script.c"
@@ -48,7 +49,8 @@ set(checks_SRC
     "src/checks/self_checks.c"
     "src/checks/validate_fees.c"
     "src/checks/verify_mix_entropy.c"
-    "src/checks/verify_protect_pubkey.c")
+    "src/checks/verify_protect_pubkey.c"
+    "src/checks/verify_no_rollback.c")
 list(APPEND main_SRC ${checks_SRC})
 
 set(include_SRC
@@ -82,6 +84,7 @@ if ($ENV{TARGET} MATCHES "nCipher")
       "src/ncipher/module_certificate.c"
       "src/ncipher/no_rollback.c"
       "src/ncipher/protection.c"
+      "src/ncipher/transact.c"
   )
   list(APPEND main_SRC ${extra_SRC})
 else ()

--- a/core/include/checks.h
+++ b/core/include/checks.h
@@ -29,6 +29,7 @@ int verify_sign_tx(void);
 int verify_validate_fees(void);
 int verify_mix_entropy(void);
 int verify_protect_pubkey(void);
+int verify_no_rollback(void);
 
 #define ASSERT_STR_EQUAL(value, expecting, message) \
   do {                                              \

--- a/core/include/config.h
+++ b/core/include/config.h
@@ -77,7 +77,6 @@
 
 #define PORT 32366
 
-#define NO_ROLLBACK_DEV_FILE "/tmp/.subzero-no-rollback"
 // VERSION_MAGIC is a constant picked randomly. Prevents accidentally swapping nvram between different applications.
 #define VERSION_MAGIC 0x20de
 

--- a/core/include/no_rollback.h
+++ b/core/include/no_rollback.h
@@ -2,4 +2,11 @@
 
 #include <squareup/subzero/internal.pb.h>
 
+#include "config.h"
+
 Result no_rollback(void);
+Result no_rollback_check(const char* filename, bool allow_upgrade, uint32_t expected_magic, uint32_t expected_version);
+Result no_rollback_write_version(const char* filename, uint32_t magic, uint32_t version);
+
+Result no_rollback_read(const char* filename, char buf[static VERSION_SIZE]);
+Result no_rollback_write(const char* filename, char buf[static VERSION_SIZE]);

--- a/core/include/transact.h
+++ b/core/include/transact.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <seelib.h>
+
+#include <squareup/subzero/internal.pb.h>
+
+Result transact(M_Command *command, M_Reply *reply);
+

--- a/core/src/checks/self_checks.c
+++ b/core/src/checks/self_checks.c
@@ -51,6 +51,12 @@ int run_self_checks() {
     ERROR("self check failure: verify_validate_fees failed.");
   }
 
+  t = verify_no_rollback();
+  if (t != 0) {
+    r = -1;
+    ERROR("self check failure: verify_no_rollback failed.");
+  }
+
   // environment specific additional checks + cleanup
   t = post_run_self_checks();
   if (t != 0) {

--- a/core/src/checks/verify_no_rollback.c
+++ b/core/src/checks/verify_no_rollback.c
@@ -1,0 +1,61 @@
+#include "checks.h"
+#include "log.h"
+#include "no_rollback.h"
+
+int verify_no_rollback() {
+  char verify_file[] = "selfcheck";
+  Result r;
+  r = no_rollback_write_version(verify_file, 1, 1);
+  if (r != Result_SUCCESS) {
+    ERROR("verify_no_rollback: no_rollback_write_version failed: %d", r);
+    return -1;
+  }
+
+  ERROR("(next line is expected to show red text...)");
+  r = no_rollback_check(verify_file, true, 0, 1); // should fail with incorrect magic
+  if (r != Result_NO_ROLLBACK_INVALID_MAGIC) {
+    ERROR("verify_no_rollback: expecting incorrect magic, got %d", r);
+    return -1;
+  }
+
+  ERROR("(next line is expected to show red text...)");
+  r = no_rollback_check(verify_file, true, 1, 0); // should fail with rollback detected
+  if (r != Result_NO_ROLLBACK_INVALID_VERSION) {
+    ERROR("verify_no_rollback: expecting incorrect version (1), got %d", r);
+    return -1;
+  }
+
+  r = no_rollback_check(verify_file, true, 1, 1); // should succeed
+  if (r != Result_SUCCESS) {
+    ERROR("verify_no_rollback: expecting success (1), got: %d", r);
+    return -1;
+  }
+
+  r = no_rollback_check(verify_file, true, 1, 1); // should succeed
+  if (r != Result_SUCCESS) {
+    ERROR("verify_no_rollback: expecting success (2), got: %d", r);
+    return -1;
+  }
+
+  r = no_rollback_check(verify_file, true, 1, 2); // should succeed
+  if (r != Result_SUCCESS) {
+    ERROR("verify_no_rollback: expecting success (3), got: %d", r);
+    return -1;
+  }
+
+  r = no_rollback_check(verify_file, true, 1, 2); // should succeed
+  if (r != Result_SUCCESS) {
+    ERROR("verify_no_rollback: expecting success (4), got: %d", r);
+    return -1;
+  }
+
+  ERROR("(next line is expected to show red text...)");
+  r = no_rollback_check(verify_file, true, 1, 1); // should fail with rollback detected
+  if (r != Result_NO_ROLLBACK_INVALID_VERSION) {
+    ERROR("verify_no_rollback: expecting incorrect version (2), got %d", r);
+    return -1;
+  }
+
+  INFO("verify_no_rollback: ok");
+  return 0;
+}

--- a/core/src/dev/no_rollback.c
+++ b/core/src/dev/no_rollback.c
@@ -7,60 +7,37 @@
 #include "config.h"
 #include "log.h"
 
-static void no_rollback_write(void);
+Result no_rollback_read(const char* filename, char buf[static VERSION_SIZE]) {
+  char tmp_file[100];
+  snprintf(tmp_file, sizeof(tmp_file), "/tmp/%s", filename);
 
-/**
- * In dev, no_rollback simulates prod by using a file instead. We however don't fail if the file does not exist (and
- * instead automatically create it):
- *
- * - if file doesn't exist:
- *   - write the current version to file.
- * - else:
- *   - read the version as an int.
- *   - if the version is older than the current version:
- *     - write the current version to file.
- *   - else if the version is newer than the current version:
- *     - exit(-1).
- */
-Result no_rollback() {
-  FILE *f = fopen(NO_ROLLBACK_DEV_FILE, "r");
+  FILE *f = fopen(tmp_file, "r");
   if (f == NULL) {
-    // create the file
-    no_rollback_write();
-    return Result_SUCCESS;
+    // In dev, we magically create the file. It's one less thing to think about.
+    no_rollback_write_version(filename, VERSION_MAGIC, VERSION);
+    f = fopen(tmp_file, "r");
   }
-  // read & compare version
-  uint32_t magic, version;
-  DEBUG("reading version from %s", NO_ROLLBACK_DEV_FILE);
-  if (fscanf(f, "%u-%u", &magic, &version) != 2) {
-    return Result_NO_ROLLBACK_INVALID_FORMAT;
-  }
+  fread(buf, 1, VERSION_SIZE, f);
   fclose(f);
-  if (magic != VERSION_MAGIC) {
-    ERROR("Unexpected magic number. Exiting");
-    return Result_NO_ROLLBACK_INVALID_MAGIC;
-  }
-  if (version > VERSION) {
-    ERROR("Rollback detected! Exiting");
-    return Result_NO_ROLLBACK_INVALID_VERSION;
-  } else if (version < VERSION) {
-    no_rollback_write();
-  } else {
-    assert(version == VERSION);
-    INFO("version match.");
-  }
   return Result_SUCCESS;
 }
 
-static void no_rollback_write() {
-  // create the file
-  FILE *f = fopen(NO_ROLLBACK_DEV_FILE, "w");
+Result no_rollback_write(const char* filename, char buf[static VERSION_SIZE]) {
+  char tmp_file[100];
+  snprintf(tmp_file, sizeof(tmp_file), "/tmp/%s", filename);
+
+  FILE *f = fopen(tmp_file, "w");
   if (f == NULL) {
-    ERROR("Failed to write %s. Exiting.", NO_ROLLBACK_DEV_FILE);
-    exit(-1);
+    ERROR("no_rollback_write failed");
+    return Result_NO_ROLLBACK_FILE_NOT_FOUND;
   }
-  // write version
-  DEBUG("writing version file (%s).", NO_ROLLBACK_DEV_FILE);
-  fprintf(f, "%d-%d", VERSION_MAGIC, VERSION);
+  size_t bytes_written = fwrite(buf, 1, VERSION_SIZE, f);
   fclose(f);
+  if (bytes_written != VERSION_SIZE) {
+    INFO("fwrite returned %zd, expecting %d", bytes_written, VERSION_SIZE);
+    return Result_NO_ROLLBACK_FILE_NOT_FOUND;
+  }
+
+  return Result_SUCCESS;
 }
+

--- a/core/src/ncipher/module_certificate.c
+++ b/core/src/ncipher/module_certificate.c
@@ -6,8 +6,8 @@
 #include "module_certificate.h"
 #include "log.h"
 #include "memzero.h"
+#include "transact.h"
 
-extern NFastApp_Connection conn;
 extern NFast_AppHandle app;
 
 /**
@@ -19,23 +19,18 @@ Result module_certificate_init(M_CertificateList *cert_list, M_Certificate *cert
   int signer_count = 0;
   M_Command command;
   M_Reply reply;
-  M_Status retcode;
+  Result r;
 
   memzero(&command, sizeof(command));
   memzero(&reply, sizeof(reply));
 
   command.cmd = Cmd_GetWorldSigners;
 
-  retcode = NFastApp_Transact(conn, NULL, &command, &reply, NULL);
-  if (retcode != Status_OK) {
-    ERROR("NFastApp_Transact failed");
-    return Result_NFAST_APP_TRANSACT_FAILURE;
-  }
-
-  if ((retcode = reply.status) != Status_OK) {
-    ERROR("NFastApp_Transact failed");
+  r = transact(&command, &reply);
+  if (r != Result_SUCCESS) {
+    ERROR("module_certificate_init: transact failed.");
     NFastApp_Free_Reply(app, NULL, NULL, &reply);
-    return Result_NFAST_APP_TRANSACT_STATUS_FAILURE;
+    return r;
   }
 
   signer_count = reply.reply.getworldsigners.n_sigs;

--- a/core/src/ncipher/no_rollback.c
+++ b/core/src/ncipher/no_rollback.c
@@ -9,32 +9,19 @@
 #include "no_rollback.h"
 #include "config.h"
 #include "log.h"
+#include "transact.h"
 
-static void no_rollback_write(void);
-static int no_rollback_read(void);
-
-extern NFastApp_Connection conn;
 extern NFast_AppHandle app;
 
 /**
- * no_rollback() provides rollback protection. The code prevents using older
- * versions of signed CodeSafe code after a newer version has been deployed. We
- * thus limit the attack surface to only the latest version of our code, as
- * opposed to any version which has ever been signed.
- *
- * Rollback protection works by storing a magic number & a version number in the
- * HSMs NVRAM. The NVRAM is protected using ACLs, so only the Codesafe code can
- * write to it.
- *
- * The magic number prevents swapping NVRAM between applications. The version
- * number is a high water mark, used to track which versions of the signed code
- * have been seen.
- *
  * Creating a fresh NVRAM requires an ACS quorum.
- * TODO: document NVRAM creation + ACL setup process.
- * TODO: experiment with the INCR ACL.
  *
- * To delete or allocate the NVRAM. By default, the NVRAM is 100 bytes:
+ * The process to create the NVRAM and setup the ACLs will live in the Java gui app.
+ *
+ * Note: we decided not to use the INCR instruction. We feel it's overly complicated.
+ *
+ * When testing, the following commands can be used to delete or allocate the NVRAM.
+ * By default, the NVRAM is 100 bytes:
  * /opt/nfast/bin/nvram-sw -d
  * /opt/nfast/bin/nvram-sw -a
  *
@@ -48,100 +35,24 @@ extern NFast_AppHandle app;
  * - ensure code works and upgrades if the version number is smaller.
  * - ensure code works if the version number is an exact match
  * - ensure code fails if the version number is greater.
- *
- * TODO: we could put no_rollback() in src/ and have no_rollback_read() +
- * no_rollback_write() live in the dev/ + ncipher/ folders.
  */
 
-Result no_rollback() {
-  int version;
-
-  version = no_rollback_read();
-  if (version == -1) {
-    ERROR("no_rollback: no_rollback_read() failed. Exiting.");
-    // TODO: convert no_rollback_read to return a Result
-    return Result_NO_ROLLBACK_INVALID_VERSION;
-  }
-  DEBUG("no_rollback: NVRAM version is %d.", version);
-
-  if (version > VERSION) {
-    ERROR("no_rollback: rollback detected! Exiting");
-    return Result_NO_ROLLBACK_INVALID_VERSION;
-  } else if (version < VERSION) {
-    ERROR("no_rollback: updating version stored in NVRAM.");
-    no_rollback_write();
-    // todo: we should re-read!
-  } else {
-    assert(version == VERSION);
-    INFO("no_rollback: version match.");
-  }
-  return Result_SUCCESS;
-}
-
-// For some unknown reason, NFastApp_Transact with -O2 requires
-// heap allocated buffers.
-uint8_t no_rollback_buf[VERSION_SIZE] = {0};
-
-static void no_rollback_write() {
-  M_Command command = {0};
-  M_Reply reply = {0};
-  M_Status rc;
-
-  char file_name[] = "test-file";
-  command.cmd = Cmd_NVMemOp;
-  command.args.nvmemop.module = 1; // we assume there's only HSM.
-  command.args.nvmemop.op = NVMemOpType_Write;
-  // TODO: assert file_name is <= 10 bytes + NULL
-  memcpy(&(command.args.nvmemop.name), &file_name, strlen(file_name));
-
-  snprintf((char *)no_rollback_buf, sizeof(no_rollback_buf), "%d-%d", VERSION_MAGIC,
-           VERSION);
-
-  command.args.nvmemop.val.write.data.len = sizeof(no_rollback_buf);
-  command.args.nvmemop.val.write.data.ptr = no_rollback_buf;
-
-  if ((rc = NFastApp_Transact(conn, NULL, &command, &reply, NULL)) !=
-      Status_OK) {
-    ERROR("no_rollback_write: NFastApp_Transact failed (%s).",
-          NF_Lookup(rc, NF_Status_enumtable));
-    goto exit;
-  }
-
-  if (reply.status != Status_OK) {
-    ERROR("no_rollback_write: NFastApp_Transact returned error (%d).",
-          reply.status);
-    goto exit;
-  }
-  INFO("no_rollback_write: write success");
-
-exit:
-  NFastApp_Free_Reply(app, NULL, NULL, &reply);
-}
-
-static int no_rollback_read() {
-  int version = -1;
+Result no_rollback_read(const char* filename, char buf[static VERSION_SIZE]) {
+  Result r = Result_UNKNOWN_INTERNAL_FAILURE;
 
   M_Command command = {0};
   M_Reply reply = {0};
-  M_Status rc;
 
-  char file_name[] = "test-file";
   command.cmd = Cmd_NVMemOp;
   command.args.nvmemop.module = 1; // we assume there's only HSM.
   command.args.nvmemop.op = NVMemOpType_Read;
-  memcpy(&(command.args.nvmemop.name), &file_name, strlen(file_name));
+  memcpy(&(command.args.nvmemop.name), filename, strlen(filename));
 
-  if ((rc = NFastApp_Transact(conn, NULL, &command, &reply, NULL)) !=
-      Status_OK) {
-    ERROR("no_rollback_read: NFastApp_Transact failed (%s).",
-          NF_Lookup(rc, NF_Status_enumtable));
-    goto exit;
-  }
-
-  if (reply.status != Status_OK) {
-    ERROR("no_rollback_read: NFastApp_Transact returned error (%d).",
-          reply.status);
-    goto exit;
+  r = transact(&command, &reply);
+  if (r != Result_SUCCESS) {
+    ERROR("no_rollback_read: transact failed.");
+    NFastApp_Free_Reply(app, NULL, NULL, &reply);
+    return r;
   }
 
   // Validate magic string and return the version
@@ -151,21 +62,40 @@ static int no_rollback_read() {
     DEBUG_("%02x", reply.reply.nvmemop.res.read.data.ptr[i]);
   }
   DEBUG_("\n");
-
-  int magic;
-  if (sscanf((const char *)reply.reply.nvmemop.res.read.data.ptr, "%u-%u",
-             &magic, &version) != 2) {
-    ERROR("no_rollback_read: failed to parse nvram");
-    version = -1;
-    goto exit;
-  }
-  if (magic != VERSION_MAGIC) {
-    ERROR("no_rollback_read: unexpected magic number (%d)", magic);
-    version = -1;
-    goto exit;
+  if (reply.reply.nvmemop.res.read.data.len != VERSION_SIZE) {
+    ERROR("Expecting NVRAM size to be %d, got %d", VERSION_SIZE, reply.reply.nvmemop.res.read.data.len);
+    NFastApp_Free_Reply(app, NULL, NULL, &reply);
+    return Result_UNKNOWN_INTERNAL_FAILURE;
   }
 
-exit:
+  memcpy(buf, reply.reply.nvmemop.res.read.data.ptr, VERSION_SIZE);
   NFastApp_Free_Reply(app, NULL, NULL, &reply);
-  return version;
+  return Result_SUCCESS;
+}
+
+Result no_rollback_write(const char* filename, char buf[static VERSION_SIZE]) {
+  Result r = Result_UNKNOWN_INTERNAL_FAILURE;
+
+  M_Command command = {0};
+  M_Reply reply = {0};
+
+  command.cmd = Cmd_NVMemOp;
+  command.args.nvmemop.module = 1; // we assume there's only one HSM.
+  command.args.nvmemop.op = NVMemOpType_Write;
+  // TODO: assert file_name is <= 10 bytes + NULL
+  memcpy(&(command.args.nvmemop.name), filename, strlen(filename));
+
+  command.args.nvmemop.val.write.data.len = VERSION_SIZE;
+  command.args.nvmemop.val.write.data.ptr = (unsigned char*) buf;
+
+  r = transact(&command, &reply);
+  if (r != Result_SUCCESS) {
+    ERROR("no_rollback_write: transact failed.");
+    NFastApp_Free_Reply(app, NULL, NULL, &reply);
+    return r;
+  }
+  INFO("no_rollback_write: write success");
+
+  NFastApp_Free_Reply(app, NULL, NULL, &reply);
+  return Result_SUCCESS;
 }

--- a/core/src/ncipher/transact.c
+++ b/core/src/ncipher/transact.c
@@ -1,0 +1,35 @@
+#include <nfastapp.h>
+
+#include "log.h"
+#include "transact.h"
+
+/**
+ * Sets certs_present and takes care of error handling.
+ *
+ * It is unclear if we need to call NFastApp_Free_Command and NFastApp_Free_Reply for stack allocated buffers. In either
+ * case, that would happen in the caller.
+ */
+extern NFastApp_Connection conn;
+extern NFast_AppHandle app;
+extern M_CertificateList cert_list;
+
+Result transact(M_Command *command, M_Reply *reply) {
+  if (command->cmd != Cmd_GetWorldSigners) {
+    // Set certs_present, unless we are asking the HSM for the certs in the first place.
+    command->certs = &cert_list;
+    command->flags |= Command_flags_certs_present;
+  }
+
+  M_Status rc;
+  if ((rc = NFastApp_Transact(conn, NULL, command, reply, NULL)) != Status_OK) {
+    ERROR("transact: NFastApp_Transact failed (%s).", NF_Lookup(rc, NF_Status_enumtable));
+    return Result_NFAST_APP_TRANSACT_FAILURE;
+  }
+  if (reply->status != Status_OK) {
+    char buf[1000];
+    NFast_StrError(buf, sizeof(buf), reply->status, NULL);
+    ERROR("transact: NFastApp_Transact returned error (%d) (%s).", reply->status, buf);
+    return Result_NFAST_APP_TRANSACT_STATUS_FAILURE;
+  }
+  return Result_SUCCESS;
+}

--- a/core/src/no_rollback.c
+++ b/core/src/no_rollback.c
@@ -1,0 +1,65 @@
+#include "no_rollback.h"
+#include "log.h"
+
+/**
+ * Prevents running an older version of core after a newer version has been seen. The goal is to limit the attack
+ * surface to only the current version (vs any version which ever existed).
+  *
+ * The code in this file is dev/ncipher agnostic. We prevent rollback by persisting a magic number and a version number.
+ * The magic number prevents accidentally mixing rollback protection code from another application. The version is
+ * a high water mark and gets automatically bumped if needed when the application starts.
+ *
+ * dev/no_rollback.c uses a file (/tmp/subzero00).
+ * ncipher/no_rollback.c uses the NVRAM, which needs to be configured with the proper ACLs when the HSM is enrolled.
+ */
+Result no_rollback(void) {
+  INFO("in no_rollback");
+
+  return no_rollback_check("subzero00", true, VERSION_MAGIC, VERSION);
+}
+
+Result no_rollback_check(const char* filename, bool allow_upgrade, uint32_t expected_magic, uint32_t expected_version) {
+  char buf[VERSION_SIZE];
+
+  Result r = no_rollback_read(filename, buf);
+  if (r != Result_SUCCESS) {
+    ERROR("no_rollback_check: no_rollback_read failed");
+    return r;
+  }
+
+  uint32_t magic, version, matches;
+  matches = sscanf(buf, "%u-%u", &magic, &version);
+  if (matches != 2) {
+    ERROR("no_rollback_check: invalid format failure");
+    return Result_NO_ROLLBACK_INVALID_FORMAT;
+  }
+  if (magic != expected_magic) {
+    ERROR("no_rollback_check: invalid magic failure");
+    return Result_NO_ROLLBACK_INVALID_MAGIC;
+  }
+
+  if (allow_upgrade && (version < expected_version)) {
+    INFO("no_rollback_check: bumping version from %d to %d", version, expected_version);
+    r = no_rollback_write_version(filename, expected_magic, expected_version);
+    if (r != Result_SUCCESS) {
+      return r;
+    }
+
+    // re-read to ensure everything is ok
+    return no_rollback_check(filename, false, expected_magic, expected_version);
+  } else if (version == expected_version) {
+    INFO("no_rollback: ok");
+    return Result_SUCCESS;
+  }
+  ERROR("no_rollback_check: invalid version failure");
+  return Result_NO_ROLLBACK_INVALID_VERSION;
+}
+
+Result no_rollback_write_version(const char* filename, uint32_t magic, uint32_t version) {
+  DEBUG("in no_rollback_write");
+
+  char buf[VERSION_SIZE];
+  bzero(buf, VERSION_SIZE);
+  snprintf(buf, sizeof(buf), "%d-%d", magic, version);
+  return no_rollback_write(filename, buf);
+}


### PR DESCRIPTION
Most of the logic in ncipher/no_rollback.c and dev/no_rollback.c can be combined
into src/no_rollback.c

The I/O part of the code remains in env-specific implementations.

Add some verification logic at startup.