### PR TITLE
Fix fake_ncipher

### DIFF
--- a/java/fake_ncipher/src/main/java/com/ncipher/nfast/marshall/M_Cmd.java
+++ b/java/fake_ncipher/src/main/java/com/ncipher/nfast/marshall/M_Cmd.java
@@ -1,5 +1,5 @@
 package com.ncipher.nfast.marshall;
 
 public class M_Cmd implements Marshallable {
-  public static final int GetTicket = 0;
+  public static int GetTicket = 0;
 }

--- a/java/fake_ncipher/src/main/java/com/ncipher/nfast/marshall/M_KeyType.java
+++ b/java/fake_ncipher/src/main/java/com/ncipher/nfast/marshall/M_KeyType.java
@@ -1,5 +1,5 @@
 package com.ncipher.nfast.marshall;
 
 public class M_KeyType implements Marshallable {
-  public static final int Rijndael = 0;
+  public static int Rijndael = 0;
 }

--- a/java/fake_ncipher/src/main/java/com/ncipher/nfast/marshall/M_TicketDestination.java
+++ b/java/fake_ncipher/src/main/java/com/ncipher/nfast/marshall/M_TicketDestination.java
@@ -1,5 +1,5 @@
 package com.ncipher.nfast.marshall;
 
 public class M_TicketDestination implements Marshallable {
-  public static final int Any = 0;
+  public static int Any = 0;
 }


### PR DESCRIPTION
Fake ncipher cannot contain any final variables, as those get constant
folded at compile time.

By making these variables non-final, we ensure that we can safely swap
the fake ncipher for a real nCipherKM.jar