### PR TITLE
remove code to create pubkeyenckey

### DIFF
--- a/java/gui/src/main/java/com/squareup/subzero/SubzeroGui.java
+++ b/java/gui/src/main/java/com/squareup/subzero/SubzeroGui.java
@@ -32,9 +32,6 @@ public class SubzeroGui {
   // Almost always you want to talk to subzero on localhost
   @Parameter(names = "--hostname") public String hostname = "localhost";
 
-  // Needed for bootstrapping
-  @Parameter(names = "--create-pub-key-encryption-key") public Boolean createPubKeyEncryptionKey = false;
-
   public SubzeroConfig config;
   private Screens screens;
 

--- a/java/gui/src/main/java/com/squareup/subzero/actions/InitWallet.java
+++ b/java/gui/src/main/java/com/squareup/subzero/actions/InitWallet.java
@@ -64,11 +64,6 @@ public class InitWallet {
 
       nCipher.loadSoftcard(subzero.config.softcard, subzero.config.getSoftcardPassword(), subzero.config.pubKeyEncryptionKey);
 
-      // Check if we need to create the pub key encryption key (only needs to happen once, on one machine)
-      if (subzero.createPubKeyEncryptionKey) {
-        nCipher.createPubKeyEncryptionKeyTicket();
-      }
-
       internalRequest.setPubKeyEncryptionKeyTicket(ByteString.copyFrom(nCipher.getPubKeyEncryptionKeyTicket()));
     }
 

--- a/java/gui/src/main/java/com/squareup/subzero/ncipher/NCipher.java
+++ b/java/gui/src/main/java/com/squareup/subzero/ncipher/NCipher.java
@@ -194,28 +194,6 @@ public class NCipher {
     pubKeyEncryptionKey = securityWorld.getKey("simple", pubKeyEncryptionKeyName);
   }
 
-  /**
-   * There is currently no way to call this code. We should either expose a flag in the CLI or
-   * move this into some kind of SecurityWorld initializer.
-   */
-  public void createPubKeyEncryptionKeyTicket() throws NFException {
-    // Create AES pubKeyEncryptionKey. In order to be able to use the key in CodeSafe, we
-    // must create a non-Java key.
-    KeyGenerator keyGenerator = securityWorld.getKeyGenerator();
-    M_KeyGenParams m_keyGenParams =
-        new M_KeyGenParams(M_KeyType.Rijndael, new M_KeyType_GenParams_Random(256 / 8));
-
-    pubKeyEncryptionKey = keyGenerator.generateUnrecordedKey(m_keyGenParams, module, softcard,
-        dataSigningKey,true);
-
-    pubKeyEncryptionKey.setName("PubKeyEncryptionKey");
-    pubKeyEncryptionKey.setAppName("simple");
-    pubKeyEncryptionKey.makeBlobs(softcard);
-    pubKeyEncryptionKey.save();
-    System.out.println(format("created pubKeyEncryptionKey: %s", pubKeyEncryptionKey.getIdent()));
-    pubKeyEncryptionKey.unLoad();
-  }
-
   public byte[] getPubKeyEncryptionKeyTicket()
       throws NFException {
     M_Ticket pubKeyEncryptionKeyTicket = getTicket( pubKeyEncryptionKey.load(softcard, module));


### PR DESCRIPTION
We now have instructions (https://subzero.readthedocs.io/en/master/hsm_initialization/)
which explain how to create this key using /opt/nfast/bin/generatekey. Creating
the key using Java is not necessary.