### PR TITLE
Improve error handling in debug server

### DIFF
--- a/java/server/src/main/java/com/squareup/subzero/server/ServerApplication.java
+++ b/java/server/src/main/java/com/squareup/subzero/server/ServerApplication.java
@@ -1,13 +1,14 @@
 package com.squareup.subzero.server;
 
 import com.squareup.subzero.server.resources.AssetsResource;
+import com.squareup.subzero.server.resources.ComputeResource;
 import com.squareup.subzero.server.resources.ConstantsResource;
 import com.squareup.subzero.server.resources.GenerateQrCodeResource;
 import com.squareup.subzero.server.resources.PrettyPrintResource;
-import com.squareup.subzero.server.resources.ComputeResource;
 import com.squareup.subzero.server.resources.ShowFinalTransactionResource;
 import io.dropwizard.Application;
 import io.dropwizard.assets.AssetsBundle;
+import io.dropwizard.jersey.setup.JerseyEnvironment;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 
@@ -29,11 +30,13 @@ public class ServerApplication extends Application<ServerConfiguration> {
 
     @Override
     public void run(final ServerConfiguration configuration, final Environment environment) {
-        environment.jersey().register(new AssetsResource());
-        environment.jersey().register(new ConstantsResource());
-        environment.jersey().register(new PrettyPrintResource());
-        environment.jersey().register(new GenerateQrCodeResource());
-        environment.jersey().register(new ComputeResource());
-        environment.jersey().register(new ShowFinalTransactionResource());
+        JerseyEnvironment jersey = environment.jersey();
+        jersey.register(new AssetsResource());
+        jersey.register(new ConstantsResource());
+        jersey.register(new PrettyPrintResource());
+        jersey.register(new GenerateQrCodeResource());
+        jersey.register(new ComputeResource());
+        jersey.register(new ShowFinalTransactionResource());
+        jersey.register(new ServerExceptionMapper());
     }
 }

--- a/java/server/src/main/java/com/squareup/subzero/server/ServerExceptionMapper.java
+++ b/java/server/src/main/java/com/squareup/subzero/server/ServerExceptionMapper.java
@@ -1,0 +1,14 @@
+package com.squareup.subzero.server;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+public class ServerExceptionMapper implements ExceptionMapper<Throwable> {
+  public Response toResponse(Throwable exception) {
+    return Response.status(400)
+        .entity(exception.getMessage())
+        .type(MediaType.TEXT_PLAIN)
+        .build();
+  }
+}

--- a/java/server/src/main/java/com/squareup/subzero/server/resources/PrettyPrintResource.java
+++ b/java/server/src/main/java/com/squareup/subzero/server/resources/PrettyPrintResource.java
@@ -24,45 +24,37 @@ public class PrettyPrintResource {
 
   @Path("/request")
   @GET
-  public String request(@QueryParam("raw") String raw) {
-    try {
-      byte[] rawBytes = base64().decode(raw);
-      Service.CommandRequest command = Service.CommandRequest.parseFrom(rawBytes);
-      String json = JsonFormat.printer().print(command);
-      if (command.hasInitWallet()) {
-        return "init wallet request: " + json;
-      }
-      if (command.hasFinalizeWallet()) {
-        return "finalize wallet request: " + json;
-      }
-      if (command.hasSignTx()) {
-        return "sign tx request: " + json;
-      }
-      return json;
-    } catch (InvalidProtocolBufferException | IllegalArgumentException e) {
-      return e.getMessage();
+  public String request(@QueryParam("raw") String raw) throws InvalidProtocolBufferException {
+    byte[] rawBytes = base64().decode(raw);
+    Service.CommandRequest command = Service.CommandRequest.parseFrom(rawBytes);
+    String json = JsonFormat.printer().print(command);
+    if (command.hasInitWallet()) {
+      return "init wallet request: " + json;
     }
+    if (command.hasFinalizeWallet()) {
+      return "finalize wallet request: " + json;
+    }
+    if (command.hasSignTx()) {
+      return "sign tx request: " + json;
+    }
+    return json;
   }
 
   @Path("/response")
   @GET
-  public String response(@QueryParam("raw") String raw) {
-    try {
-      byte[] rawBytes = base64().decode(raw);
-      Service.CommandResponse command = Service.CommandResponse.parseFrom(rawBytes);
-      String json = JsonFormat.printer().print(command);
-      if (command.hasInitWallet()) {
-        return "init wallet response: " + json;
-      }
-      if (command.hasFinalizeWallet()) {
-        return "finalize wallet response: " + json;
-      }
-      if (command.hasSignTx()) {
-        return "sign tx response: " + json;
-      }
-      return json;
-    } catch (InvalidProtocolBufferException | IllegalArgumentException e) {
-      return e.getMessage();
+  public String response(@QueryParam("raw") String raw) throws InvalidProtocolBufferException {
+    byte[] rawBytes = base64().decode(raw);
+    Service.CommandResponse command = Service.CommandResponse.parseFrom(rawBytes);
+    String json = JsonFormat.printer().print(command);
+    if (command.hasInitWallet()) {
+      return "init wallet response: " + json;
     }
+    if (command.hasFinalizeWallet()) {
+      return "finalize wallet response: " + json;
+    }
+    if (command.hasSignTx()) {
+      return "sign tx response: " + json;
+    }
+    return json;
   }
 }

--- a/java/server/src/main/resources/assets/index.html
+++ b/java/server/src/main/resources/assets/index.html
@@ -22,6 +22,7 @@
   <p>Display the contents of a request or response. Useful for debugging purpose.</p>
   <p>raw: <textarea id="pretty_print_raw"></textarea></p>
   <p><button onClick="pretty_print_request()">decode request</button> <button onClick="pretty_print_response()">decode response</button></p>
+  <div id="pretty_print_error" class="error" style="display: none"></div>
   <div id="pretty_print_response" class="response" style="display: none">
     <p>json: <textarea disabled="true" id="pretty_print_json"></textarea></p>
   </div>
@@ -47,6 +48,7 @@
   <div id="init_responses">
   </div>
   <p><button onClick="finalize_wallet_request()">generate QR code</button></p>
+  <div id="finalize_wallet_error" class="error" style="display: none"></div>
   <div id="finalize_wallet_response" class="response" style="display: none">
     <canvas id="finalize_wallet_response_qr" width="400"></canvas>
     <div id="finalize_wallet_response_data"></div>
@@ -58,6 +60,7 @@
   <div id="finalize_response">
   </div>
   <p><button onClick="reveal_xpubs()">reveal xpubs</button></p>
+  <div id="reveal_xpubs_error" class="error" style="display: none"></div>
   <div id="reveal_xpubs_response" class="response" style="display: none">
     <p>xpubs: <textarea disabled="true" id="reveal_xpubs_response_data"></textarea></p>
   </div>
@@ -69,6 +72,7 @@
   <p>change: <input type="checkbox" id="derive_address_change"></p>
   <p>index: <input type="text" id="derive_address_index" size="10"> (BIP-32)</p>
   <p><button onClick="derive_address()">derive address</button></p>
+  <div id="derive_address_error" class="error" style="display: none"></div>
   <div id="derive_address_response" class="response" style="display: none">
     <p>address: <input type="text" size="70" disabled="true" id="derive_address_response_data"/></p>
   </div>
@@ -88,6 +92,7 @@
   <p><button class="small" style="margin-left: 2em;" onClick="addOutput(false)">add more outputs</button></p>
 
   <p><button onClick="sign_tx_request()">generate QR code</button></p>
+  <div id="sign_tx_error" class="error" style="display: none"></div>
   <div id="sign_tx_response" class="response" style="display: none">
     <canvas id="sign_tx_response_qr" width="400"></canvas>
     <div id="sign_tx_response_data"></div>
@@ -103,6 +108,7 @@
   <p>Gateway xpub: <textarea id="gateway"></textarea></p>
   <div id="merge_responses"></div>
   <p><button onClick="show_final_transaction()">show final transaction</button></p>
+  <div id="show_final_transaction_error" class="error" style="display: none"></div>
   <div id="show_final_transaction_response" class="response" style="display: none">
     <p>transaction: <textarea disabled="true" id="show_final_transaction_response_data"></textarea></p>
   </div>

--- a/java/server/src/main/resources/assets/server.css
+++ b/java/server/src/main/resources/assets/server.css
@@ -55,3 +55,8 @@ input[type=text] {
   padding: 1px;
   border-radius: 2px;
 }
+
+.error {
+  color: red;
+  font-size: 8pt;
+}

--- a/java/server/src/main/resources/assets/server.js
+++ b/java/server/src/main/resources/assets/server.js
@@ -6,19 +6,35 @@
 // using a real framework...
 
 function pretty_print_request() {
-  $('#pretty_print_response').slideDown();
+  $('#pretty_print_error').hide();
+  $('#pretty_print_response').hide();
   $.ajax("/pretty-print/request", {
     data: {"raw": pretty_print_raw.value}
   })
-  .done(result => pretty_print_json.value = result);
+  .fail((jqXhr, status) => {
+    $('#pretty_print_error').text(status + ": " + jqXhr.responseText);
+    $('#pretty_print_error').slideDown();
+  })
+  .done(result => {
+    pretty_print_json.value = result;
+    $('#pretty_print_response').slideDown();
+  });
 }
 
 function pretty_print_response() {
-  $('#pretty_print_response').slideDown();
+  $('#pretty_print_error').hide();
+  $('#pretty_print_response').hide();
   $.ajax("/pretty-print/response", {
     data: {"raw": pretty_print_raw.value}
   })
-  .done(result => pretty_print_json.value = result);
+  .fail((jqXhr, status) => {
+    $('#pretty_print_error').text(status + ": " + jqXhr.responseText);
+    $('#pretty_print_error').slideDown();
+  })
+  .done(result => {
+    pretty_print_json.value = result;
+    $('#pretty_print_response').slideDown();
+  });
 }
 
 function init_wallet_request() {
@@ -45,7 +61,8 @@ function init_wallet_request() {
 }
 
 function finalize_wallet_request() {
-  $('#finalize_wallet_response').slideDown();
+  $('#finalize_wallet_error').hide();
+  $('#finalize_wallet_response').hide();
 
   var data = {"wallet": wallet.value|0, "encPubKeys": []};
   for (var i=1; i<=N.innerText; i++) {
@@ -53,6 +70,10 @@ function finalize_wallet_request() {
   }
 
   $.ajax("/generate-qr-code/finalize-wallet-request", {traditional: true, data: data})
+  .fail((jqXhr, status) => {
+    $('#finalize_wallet_error').text(status + ": " + jqXhr.responseText);
+    $('#finalize_wallet_error').slideDown();
+  })
   .done(result => {
     finalize_wallet_response_data.innerText = result.data;
     var r = Math.floor(finalize_wallet_response_qr.width / result.size);
@@ -68,11 +89,13 @@ function finalize_wallet_request() {
         }
       }
     }
+    $('#finalize_wallet_response').slideDown();
   });
 }
 
 function reveal_xpubs() {
-  $('#reveal_xpubs_response').slideDown();
+  $('#reveal_xpubs_error').hide();
+  $('#reveal_xpubs_response').hide();
 
   var data = {"finalizeResponses": []};
   for (var i=1; i<=N.innerText; i++) {
@@ -80,13 +103,19 @@ function reveal_xpubs() {
   }
 
   $.ajax("/compute/xpubs", {traditional: true, data: data})
+  .fail((jqXhr, status) => {
+    $('#reveal_xpubs_error').text(status + ": " + jqXhr.responseText);
+    $('#reveal_xpubs_error').slideDown();
+  })
   .done(results => {
     reveal_xpubs_response_data.value = results.join("\n");
+    $('#reveal_xpubs_response').slideDown();
   });
 }
 
 function derive_address() {
-  $('#derive_address_response').slideDown();
+  $('#derive_address_error').hide();
+  $('#derive_address_response').hide();
 
   var data = {"finalizeResponses": []};
   for (var i=1; i<=N.innerText; i++) {
@@ -96,13 +125,19 @@ function derive_address() {
   data.index = $('#derive_address_index').val();
 
   $.ajax("/compute/address", {traditional: true, data: data})
+  .fail((jqXhr, status) => {
+    $('#derive_address_error').text(status + ": " + jqXhr.responseText);
+    $('#derive_address_error').slideDown();
+  })
   .done(results => {
     derive_address_response_data.value = results;
+    $('#derive_address_response').slideDown();
   });
 }
 
 function sign_tx_request() {
-  $('#sign_tx_response').slideDown();
+  $('#sign_tx_error').hide();
+  $('#sign_tx_response').hide();
 
   var data = {
     "wallet": wallet.value|0,
@@ -113,6 +148,10 @@ function sign_tx_request() {
     rate: exchange_rate.value
   };
   $.ajax("/generate-qr-code/sign-tx-request", {type: "POST", contentType: "application/json", processData: false, data: JSON.stringify(data)})
+  .fail((jqXhr, status) => {
+    $('#sign_tx_error').text(status + ": " + jqXhr.responseText);
+    $('#sign_tx_error').slideDown();
+  })
   .done(result => {
     sign_tx_response_data.innerText = result.data;
     var r = Math.floor(sign_tx_response_qr.width / result.size);
@@ -128,11 +167,13 @@ function sign_tx_request() {
         }
       }
     }
+    $('#sign_tx_response').slideDown();
   });
 }
 
 function show_final_transaction() {
-  $('#show_final_transaction_response').slideDown();
+  $('#show_final_transaction_error').hide();
+  $('#show_final_transaction_response').hide();
   var data = {
     signTxRequest: initial_sign_tx_request.value,
     finalizeResponses: [],
@@ -146,8 +187,13 @@ function show_final_transaction() {
     data.signTxResponses.push($('#sign_tx_response_' + i).val());
   }
   $.ajax("/show-final-transaction", {traditional: true, data: data})
+  .fail((jqXhr, status) => {
+    $('#show_final_transaction_error').text(status + ": " + jqXhr.responseText);
+    $('#show_final_transaction_error').slideDown();
+  })
   .done(results => {
     show_final_transaction_response_data.value = results;
+    $('#show_final_transaction_response').slideDown();
   });
 }
 

--- a/java/shared/src/main/java/com/squareup/subzero/shared/SubzeroUtils.java
+++ b/java/shared/src/main/java/com/squareup/subzero/shared/SubzeroUtils.java
@@ -341,13 +341,12 @@ public class SubzeroUtils {
     for (NetworkParameters network : Networks.get()) {
       try {
         deserializeB58(base58address, network);
-        params = network;
-        break;
+        return network;
       } catch (IllegalArgumentException e) {
         continue;
       }
     }
-    return params;
+    throw new IllegalArgumentException(format("Failed to infer network parameters from %s", base58address));
   }
 
   public static List<String> finalizeResponsesToAddresses(List<String> finalizeResponses)


### PR DESCRIPTION
Previously, we were silently ignoring any exception thrown by the
backend. With this change, an error message gets rendered.

Better error handling implies we can remove two unnecessary try/catch
blocks and just let the exception propagate.

Finally replaces a null with an exception.

The combination of these makes situations such as
https://github.com/square/subzero/issues/119 easier to debug.