### PR TITLE
Remove unused dependency

### DIFF
--- a/java/server/pom.xml
+++ b/java/server/pom.xml
@@ -37,11 +37,6 @@
             <artifactId>dropwizard-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.dropwizard</groupId>
-            <artifactId>dropwizard-views-mustache</artifactId>
-            <version>${dropwizard.version}</version>
-        </dependency>
-        <dependency>
             <groupId>com.squareup.subzero</groupId>
             <artifactId>proto</artifactId>
             <version>1.0.0-SNAPSHOT</version>


### PR DESCRIPTION
Hello, it seems that dependency `dropwizard-views-mustache`, declared in module `server`, is not used. This dependency has also other unused dependencies, as shown in the dependency tree:

```
. . .
 +- io.dropwizard:dropwizard-views-mustache:jar:1.3.8:compile
 |  +- io.dropwizard:dropwizard-views:jar:1.3.8:compile
 |  |  \- (io.dropwizard:dropwizard-core:jar:1.3.8:compile - omitted for duplicate)
 |  \- com.github.spullara.mustache.java:compiler:jar:0.9.5:compile
. . .
```
Therefore, it can be removed safely.