### PR TITLE
--no-verify is required because of a bug between the HSM's firmware and

### DIFF
--- a/docs/hsm_initialization.md
+++ b/docs/hsm_initialization.md
@@ -295,7 +295,7 @@ New softcard created: HKLTU aa6bfaa5f222407b10fea9b30b68129d6fb7a3e4
 
 
 # Create pubKeyEncryptionKey
-[bin]$ ./generatekey simple type=AES protect=softcard softcard=subzero recovery=yes size=256 ident=pubkeyenckey plainname= seeintegname=subzerodatasigner nvram=no
+[bin]$ ./generatekey --no-verify simple type=AES protect=softcard softcard=subzero recovery=yes size=256 ident=pubkeyenckey plainname= seeintegname=subzerodatasigner nvram=no
 
 
 # The HSM is now setup for performing wallet operations.


### PR DESCRIPTION
software.

An alternative is to generate the key in the other world and transfer
it.

We should revert this commit once we upgrade the CodeSafe version to
12.60.x