### PR TITLE
Fix rendering bug

### DIFF
--- a/java/gui/src/main/java/com/squareup/subzero/framebuffer/Screens.java
+++ b/java/gui/src/main/java/com/squareup/subzero/framebuffer/Screens.java
@@ -80,7 +80,7 @@ public class Screens {
       baseScreenLayout(graphics,"Approve", instructions, Color.white);
     });
 
-    int offset = 300;
+    int offset = 320;
     while(true) {
       String input = framebuffer.prompt(18, offset, false);
 
@@ -271,3 +271,4 @@ public class Screens {
     framebuffer.pressEnter();
   }
 }
+


### PR DESCRIPTION
This temporary fix prevents typing "yes" or "no" from overwriting what's
previously on the screen. The current code is very fragile, the
rendering varies across OS platforms and many such offsets are
hardcoded.

We'll have to eventually decide if we want to completely rewrite the UI code or
if we want to refactor small pieces.