### PR TITLE
Remove trezor-crypto submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "core/nanopb"]
 	path = core/nanopb
 	url = https://github.com/nanopb/nanopb.git
-[submodule "core/trezor-crypto"]
-	path = core/trezor-crypto
-	url = https://github.com/trezor/trezor-crypto.git


### PR DESCRIPTION
This should have been done as part of
https://github.com/square/subzero/pull/85.

Having this now useless entry breaks the docs build (see
https://github.com/readthedocs/readthedocs.org/issues/6637)