### PR TITLE
Restore prev_index

### DIFF
--- a/java/server/src/main/resources/assets/server.js
+++ b/java/server/src/main/resources/assets/server.js
@@ -366,6 +366,7 @@ function loadState() {
     var input = state.inputs[i];
     var el = addInput(true);
     el.find('.prev_hash').val(input.prev_hash);
+    el.find('.prev_index').val(input.prev_index);
     el.find('.amount').val(input.amount);
     el.find('.change').prop('checked', input.change);
     el.find('.index').val(input.index);


### PR DESCRIPTION
Everytime a form element changes, the server stores the new value in
local storage. This enables us to reload all the value on a page
refresh, which is very convenient.

Restoring prev_index was however missing.