### PR TITLE
live: update nCipher security world to 12.60.11

### DIFF
--- a/live-usb-creator/README.md
+++ b/live-usb-creator/README.md
@@ -9,15 +9,17 @@ Three dependencies need to be fetched out-of-band.
 
 Set the following files in place in the same directory as the `Vagrantfile`.
 
-* CodeSafe-linux64-dev-12.50.2.iso (2.6GB): supplied by the HSM vendor.
+* SecWorld_Lin64-12.60.11.iso (316M): supplied by the HSM vendor
+* Codesafe_Lin64-12.63.0.iso (281M): supplied by the HSM vendor.
 * CentOS-7-x86_64-Everything-1908.iso (10G): `curl -O http://mirror.seas.harvard.edu/centos/7.7.1908/isos/x86_64/CentOS-7-x86_64-Everything-1908.iso`
 * kernel-devel-3.10.0-957.12.2.el7.x86_64.rpm (17MB): `curl -O http://archive.kernel.org/centos-vault/centos/7.6.1810/updates/x86_64/Packages/kernel-devel-3.10.0-957.12.2.el7.x86_64.rpm`
 
 Verify the following SHA256 sums:
 
 ```
-$ shasum -a 256 CodeSafe-linux64-dev-12.50.2.iso CentOS-7-x86_64-Everything-1908.iso kernel-devel-3.10.0-957.12.2.el7.x86_64.rpm
-23ca2c5fc2476887926409bc69f19b772c99191b1e0cce1a3bace8d1e4488528  CodeSafe-linux64-dev-12.50.2.iso
+$ shasum -a 256 SecWorld_Lin64-12.60.11.iso Codesafe_Lin64-12.63.0.iso CentOS-7-x86_64-Everything-1908.iso kernel-devel-3.10.0-957.12.2.el7.x86_64.rpm
+6eb82827d438f8dc315d1199772998d97679a0a317bcf540413792f18c3bc3a2  SecWorld_Lin64-12.60.11.iso
+df928054888f466c263ef1d7de37877bdcf27c632b34c6934b6eee4e8697a6de  Codesafe_Lin64-12.63.0.iso
 bd5e6ca18386e8a8e0b5a9e906297b5610095e375e4d02342f07f32022b13acf  CentOS-7-x86_64-Everything-1908.iso
 a27c718efb2acec969b20023ea517d06317b838714cb359e4a80e8995ac289fc  kernel-devel-3.10.0-957.12.2.el7.x86_64.rpm
 ```

--- a/live-usb-creator/bootstrap.sh
+++ b/live-usb-creator/bootstrap.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 
-# mount the CodeSafe image so we can copy stuff off it to our target image
-sudo mkdir /media/CodeSafe && sudo mount -t iso9660 -o ro /vagrant/CodeSafe-linux64-dev-12.50.2.iso /media/CodeSafe
+# mount the SecWorld + CodeSafe image so we can copy stuff off it to our target image
+sudo mkdir /media/SecWorld && sudo mount -t iso9660 -o ro /vagrant/SecWorld_Lin64-12.60.11.iso /media/SecWorld
+sudo mkdir /media/CodeSafe && sudo mount -t iso9660 -o ro /vagrant/Codesafe_Lin64-12.63.0.iso  /media/CodeSafe

--- a/live-usb-creator/install_scripts/0_post_install_nochroot
+++ b/live-usb-creator/install_scripts/0_post_install_nochroot
@@ -11,42 +11,38 @@
 mkdir /tmp/nfast_install
 pushd /tmp/nfast_install
 
-# Hardware Support (mandatory)
-tar -xf /media/CodeSafe/linux/libc6_11/amd64/nfast/hwsp/agg.tar
+# CipherTools Developer
+tar -xzf /media/SecWorld/linux/amd64/ctd.tar.gz
 
 # Core Tools (recommended)
-tar -xf /media/CodeSafe/linux/libc6_11/amd64/nfast/ctls/agg.tar
+tar -xzf /media/SecWorld/linux/amd64/ctls.tar.gz
 
-# Java Support (including KeySafe)
-tar -xf /media/CodeSafe/linux/libc6_11/amd64/nfast/javasp/agg.tar
+# nCore API Documentation
+tar -xzf /media/SecWorld/linux/amd64/devref.tar.gz
 
-# nCipherKM JCA/JCE provider classes
-tar -xf /media/CodeSafe/linux/libc6_11/amd64/nfast/jcecsp/user.tar
+# Hardware Support (mandatory)
+tar -xzf /media/SecWorld/linux/amd64/hwsp.tar.gz
 
-# nCipher PKCS #11 library
-tar -xf /media/CodeSafe/linux/libc6_11/amd64/nfast/pkcs11/user.tar
+# Java Support (including nCipherKM JCA/JCE provider, KeySafe)
+tar -xzf /media/SecWorld/linux/amd64/javasp.tar.gz
 
-# CHIL (Cryptographic Hardware Interface Library),
-# apparently required for "generatekey" utility
-tar -xf /media/CodeSafe/linux/libc6_11/amd64/nfast/hwcrhk/user.tar
+# Java dev libs for nCore API
+tar -xzf /media/SecWorld/linux/amd64/jd.tar.gz
 
-# Remote Administration Service
-tar -xf /media/CodeSafe/linux/libc6_11/amd64/nfast/dsserv/user.tar
+# nShield SNMP service and tools
+tar -xzf /media/SecWorld/linux/amd64/ncsnmp.tar.gz
 
-# Remote Administration Client Tools
-tar -xf /media/CodeSafe/linux/libc6_11/amd64/nfast/ratls/agg.tar
+# Remote Administration Service (before 12.60 this package was known as dsserv)
+tar -xzf /media/SecWorld/linux/amd64/raserv.tar.gz
 
-# nCore CodeSafe API Documentation (not in SecWorld; CodeSafe only)
-tar -xf /media/CodeSafe/linux/libc6_11/amd64/nfast/csdref/agg.tar
+# Redistributable GNU C shared libs
+tar -xzf /media/SecWorld/linux/amd64/redist.tar.gz
 
-# nCore API Documentation (not in SecWorld; CodeSafe only)
-tar -xf /media/CodeSafe/linux/libc6_11/amd64/nfast/devref/agg.tar
+# CodeSafe Developer; example programs, and SDK for CodeSafe
+tar -xzf /media/CodeSafe/linux/amd64/csd.tar.gz
 
-# CodeSafe Developer (not in SecWorld; CodeSafe only)
-tar -xf /media/CodeSafe/linux/libc6_11/amd64/nfast/csd/agg.tar
-
-# Prebuilt powerpcm-gcc for Codesafe/C (not in SecWorld; CodeSafe only)
-tar -xf /media/CodeSafe/linux/libc6_11/amd64/nfast/gccsrc/ppcdev.tar
+# Documentation for CodeSafe
+tar -xzf /media/CodeSafe/linux/amd64/csdref.tar.gz
 
 pushd opt
 mv nfast /mnt/sysimage/opt/


### PR DESCRIPTION
nCipher released the Security World Software version 12.60.11 on 2020-07-02 as GA release. This change builds the live image with SecWorld_Lin64-12.60.11.iso and Codesafe_Lin64-12.63.0.iso. Tested with a test transaction.