### PR TITLE
Fix clang build errors related to -Wstring-plus-int

### DIFF
--- a/core/include/log.h
+++ b/core/include/log.h
@@ -3,7 +3,7 @@
 #include <stdio.h>
 
 // Part 2/2 of magic to drop the full path from __FILE__
-#define __FILENAME__ (__FILE__ + SOURCE_PATH_SIZE)
+#define __FILENAME__ (&__FILE__[SOURCE_PATH_SIZE])
 
 #ifdef BTC_TESTNET
   // Print DEBUG to stdout in green


### PR DESCRIPTION
This is to make subzero build in clang on Mac OS X.
Test with clang version 9.0.1, target x86_64-apple-darwin20.2.0.