### PR TITLE
Make build faster by removing build check for protobuf

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -55,7 +55,6 @@ jobs:
         ./autogen.sh
         ./configure
         make
-        make check
         sudo make install
         sudo ldconfig
         protoc --version
@@ -68,7 +67,7 @@ jobs:
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file. 
+        # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 


### PR DESCRIPTION
Skip 'make check' after protobuf is build. This check is not essential for subzero build, and will speed up the turnaround time for the build/scan.