### PR TITLE
Migrate from Travis CI to Github Actions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: java
-dist: trusty
-
-jdk:
-  - oraclejdk8
-  - openjdk8
-
-script: ./build.sh

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://api.travis-ci.com/square/subzero.svg?branch=master)](https://travis-ci.com/square/subzero)
+[![Build Status](https://github.com/square/subzero/workflows/CodeQL/badge.svg)](https://github.com/square/subzero/actions?query=workflow%3ACodeQL)
 [![Documentation Status](https://readthedocs.org/projects/subzero/badge/?version=master)](https://subzero.readthedocs.io/en/master/?badge=master)
 [![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=square/subzero)](https://dependabot.com)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/square/subzero/blob/master/LICENSE)

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-cd java
-mvn clean install
-


### PR DESCRIPTION
Because all that is accomplished in Travis CI has been covered by the CodeQL workflow, we have decided to migrate to Github Actions completely.