### PR TITLE
Add .gitattributes for linguist-vendored files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Ignore vendored code from linguist
+# Cf. https://github.com/github/linguist#overrides
+core/external-crypto/**/* linguist-vendored
+core/trezor-crypto/**/* linguist-vendored
+core/external-crypto/CMakeLists.txt -linguist-vendored
+core/trezor-crypto/CMakeLists.txt -linguist-vendored


### PR DESCRIPTION
Exclude external-crypto/ and trezor-crypto/ from linguist language statistics.
Please refer to https://github.com/github/linguist#overrides for detail.