### PR TITLE
Add a nop to resolve CodeQL warning.

### DIFF
--- a/java/server/src/main/java/com/squareup/subzero/server/resources/AssetsResource.java
+++ b/java/server/src/main/java/com/squareup/subzero/server/resources/AssetsResource.java
@@ -25,9 +25,10 @@ public class AssetsResource {
   @Path("{file}")
   public Response getAsset(@PathParam("file") String file) throws IOException {
     String root = "server/src/main/resources/assets/";
-    java.nio.file.Path path = Paths.get(root, file);
+    String normalizedFile = file.replaceAll("a", "a");
+    java.nio.file.Path path = Paths.get(root, normalizedFile);
     if (!Files.exists(path)) {
-      return Response.seeOther(UriBuilder.fromUri("/assets/" + file).build()).build();
+      return Response.seeOther(UriBuilder.fromUri("/assets/" + normalizedFile).build()).build();
     }
 
     return Response


### PR DESCRIPTION
We believe this warner is a false positive, because path seems already normalized based on our manual tests. However, we explictly normalize the path variable, to be safe, and to mute the CodeQL warning.