### PR TITLE
SignTx regression testing for TARGET=nCipher.

### DIFF
--- a/java/gui/src/main/java/com/squareup/subzero/SubzeroGui.java
+++ b/java/gui/src/main/java/com/squareup/subzero/SubzeroGui.java
@@ -210,12 +210,6 @@ public class SubzeroGui {
 
   private void signTxTest() throws Exception {
 
-    // TODO: implement HSM test
-    if (nCipher) {
-      System.out.println("Transaction signing regression test not yet implemented for nCipher");
-      throw new NotImplementedException();
-    }
-
     // Passed and failed test cases, for valid and invalid test vectors.
     // For a valid test vector, test passes (ok) if and only if subzero response matches
     // expected response. This is for happy path testing.
@@ -227,7 +221,8 @@ public class SubzeroGui {
     int fail_invalid = 0;
 
     // Read request & expected response from src/main/resources/txsign-testvectors/.
-    // The request and expected response are pre-generated, based64-encoded proto buffers
+    // The request and expected response are pre-generated, based64-encoded proto buffers.
+    // These test vectors are the same for TARGET=dev and TARGET=nCipher subzero core build types
     FileResourceUtils util = new FileResourceUtils();
     List<Path> txsignRegressionTestsPath = util.getPathsFromResourcesJAR("txsign-testvectors");
     for (Path path : txsignRegressionTestsPath) {

--- a/java/gui/src/main/java/com/squareup/subzero/actions/SignTx.java
+++ b/java/gui/src/main/java/com/squareup/subzero/actions/SignTx.java
@@ -116,7 +116,7 @@ public class SignTx {
 
     if (subzero.nCipher) {
       nCipher.unloadOcs();
-      if (Strings.isNullOrEmpty(subzero.debug)) {
+      if (!subzero.signtxTest && Strings.isNullOrEmpty(subzero.debug)) {
         subzero.getScreens().removeOperatorCard("Please remove Operator Card and return it to the safe. Then hit <enter>.");
       }
     }

--- a/java/gui/src/main/java/com/squareup/subzero/ncipher/NCipher.java
+++ b/java/gui/src/main/java/com/squareup/subzero/ncipher/NCipher.java
@@ -167,7 +167,10 @@ public class NCipher {
       securityWorld.changePP(slot,
           new NCipherChangePasswordOCS(NCipherChangePasswordOCS.PLACEHOLDER_PASSWORD, newPassword));
     }
-    screens.renderLoading();
+    // SignTx test does not need screens, and therefore we skip the following step for it
+    if (screens != null) {
+      screens.renderLoading();
+    }
 
     // Get the data signing key
     dataSigningKey = securityWorld.getKey("seeinteg", dataSigner);

--- a/java/gui/src/main/java/com/squareup/subzero/wallet/TestWallets.java
+++ b/java/gui/src/main/java/com/squareup/subzero/wallet/TestWallets.java
@@ -7,7 +7,7 @@ package com.squareup.subzero.wallet;
  */
 
 public final class TestWallets {
-  // Test wallet 1492, share 1
+  // Test wallet 1492, share 1, for off-target dev testing.
   protected static final String devTestWallet =
       "{\"currency\":\"TEST_NET\",\"encrypted_master_seed\":{\"encrypted_master_seed\":" +
           "\"ioBg3WF2BntMnGae6PyWbp1VG4r446PUYVZnt1BzOOVQzHy3XeaqmBXS6tMbE9fsB0sR+Vi9xP" +
@@ -25,6 +25,25 @@ public final class TestWallets {
           "CCxlkz1haxZawNOD0RUdocg5/h6GjaeOqJVxI6hgD3xqJRT+8e2OjVLwJWSmwbX2ckeKz+u76bFN" +
           "xiCP2g+UCT94s8amrAeQTLXwF9lg==\"}]}";
 
-  // TODO: Implement test wallet for nChipher testing
-  protected static final String ncipherTestWallet = "TO BE IMPLEMENTED";
+  // Test wallet for on-target nChipher testing. Note that ncipherTestWallet differs
+  // from devTestWallet only in its extra "ocs_id" and "master_seed_encryption_key_id"
+  // values. We could use the string below for both test wallets, but keep them separate
+  // so that the code is easier to understand.
+  protected static final String ncipherTestWallet =
+      "{\"currency\":\"TEST_NET\",\"ocs_id\":\"adb1c4d63095d578b60d7fa3ef44f2acc435c821" +
+          "\",\"master_seed_encryption_key_id\":\"masterseedenckey128\", \"encrypted_ma" +
+          "ster_seed\":{\"encrypted_master_seed\":\"ioBg3WF2BntMnGae6PyWbp1VG4r446PUYVZ" +
+          "nt1BzOOVQzHy3XeaqmBXS6tMbE9fsB0sR+Vi9xPgJcayN2uJsJNjEw7S77h9oUUpu0zWrYvl6iRA" +
+          "I4fcezOxbRcc=\"},\"encrypted_pub_keys\":[{\"encrypted_pub_key\":\"OytXbV6n2L" +
+          "0l50yLegnaP6ea9jRDfFM0I6J/tJQzvnc2+E2Bleqvh4ZaIoTd7Nm6j9XRag1WYni/K0uoek/0rL" +
+          "nLNGZbrrQLNt5lkfTTcMZ72mEKTRkvRWbJwd8H+p86GLqSqgvofDSE5E5EkgYGhIGSkFy8dLpXK4" +
+          "jpYxAQGrIQ2tNeXKKw2nNPOQ==\"},{\"encrypted_pub_key\":\"YxgmbmaiwGON1uHpp6cp7" +
+          "sWxMNNJYbX4tqtEJwbOYqfKWW9k56V/uguQrliIwaG2X7ca6VJ01YQiiMdJciQzb3w182R/HsGiY" +
+          "YdMuHP0PNjVk9ScYby38ofTUfjW8ihUFFjM6FSs7WzZAFCuQ04bNNATuGfdXQK8pgoCHKWKTJ2c3" +
+          "alaZvIauwzkfQ==\"},{\"encrypted_pub_key\":\"i36ne27C7pv1psRFttz3oNBVZVwgh/t6" +
+          "sQO3DUDfb6Edw3GvDAea3oPQ3Fm5No3JBWp5/SARPva29lPdi4X4mz+qde2nPYMvIJtW0ndAUGU2" +
+          "kw9dhzVY/FZ8XGnIH33otuKE2i+HxOYwxk6+EqS1WEoWEqRe2LO8h1DTg9GsYzzTyjSj2OKIOGc0" +
+          "2A==\"},{\"encrypted_pub_key\":\"s/1O2nYnApJd+Mlc10rvGsMghE8AmhfIBXDBW52GBrj" +
+          "ML07IVF3pZsgPKt4mLpsf2aUcHYn4P276jrdN1rCCxlkz1haxZawNOD0RUdocg5/h6GjaeOqJVxI" +
+          "6hgD3xqJRT+8e2OjVLwJWSmwbX2ckeKz+u76bFNxiCP2g+UCT94s8amrAeQTLXwF9lg==\"}]}";
 }


### PR DESCRIPTION
The same test wallet can be used for TARGET=dev and TARGET=nCipher, in terms of SignTx regression testing. The nCipher subzero core build needs to have its associated HSM properly configured so that it shares the same AES-128-GCM keys with the off-target dev build, for master seed encryption and public key encryption. The test vectors are the same for both subzero core targets.

Note that on-target regression testing is much slower than off-target testing.