### PR TITLE
Improve CI speed by using pre-compiled x86_64 Linux binary for protubuf

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -48,18 +48,18 @@ jobs:
       run: |
         cd /tmp
         sudo apt-get update
-        sudo apt-get install autoconf automake libtool curl make g++ unzip -y
-        git clone https://github.com/google/protobuf.git
-        cd protobuf
-        git submodule update --init --recursive
-        ./autogen.sh
-        ./configure
-        make
-        sudo make install
-        sudo ldconfig
+        sudo apt-get install libtool curl make g++ unzip -y
+        curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v3.14.0/$PROTOC_ZIP
+        sudo unzip -o $PROTOC_ZIP -d /usr/local bin/protoc
+        sudo unzip -o $PROTOC_ZIP -d /usr/local 'include/*'
+        sudo chmod 755 /usr/local/bin/protoc
+        sudo chmod -R 755 /usr/local/include
+        # For debugging
         protoc --version
         python -m pip install --upgrade pip
         python -m pip install protobuf
+      env:
+        PROTOC_ZIP: protoc-3.14.0-linux-x86_64.zip
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/signtx-test.yml
+++ b/.github/workflows/signtx-test.yml
@@ -46,18 +46,18 @@ jobs:
       run: |
         cd /tmp
         sudo apt-get update
-        sudo apt-get install autoconf automake libtool curl make g++ unzip -y
-        git clone https://github.com/google/protobuf.git
-        cd protobuf
-        git submodule update --init --recursive
-        ./autogen.sh
-        ./configure
-        make
-        sudo make install
-        sudo ldconfig
+        sudo apt-get install libtool curl make g++ unzip -y
+        curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v3.14.0/$PROTOC_ZIP
+        sudo unzip -o $PROTOC_ZIP -d /usr/local bin/protoc
+        sudo unzip -o $PROTOC_ZIP -d /usr/local 'include/*'
+        sudo chmod 755 /usr/local/bin/protoc
+        sudo chmod -R 755 /usr/local/include
+        # For debugging
         protoc --version
         python -m pip install --upgrade pip
         python -m pip install protobuf
+      env:
+        PROTOC_ZIP: protoc-3.14.0-linux-x86_64.zip
 
     # Build Java targets
     - name: Build Java


### PR DESCRIPTION
Building protoc from source takes a long time and thus makes CI slow. We use pre-compiled protoc instead in this change.