### PR TITLE
Add additional software tools to the dev-flavored ISO

### DIFF
--- a/live-usb-creator/.gitignore
+++ b/live-usb-creator/.gitignore
@@ -2,3 +2,4 @@ CentOS-7-x86_64-Everything-1908.iso
 CodeSafe-linux64-dev-12.50.2.iso
 boot.iso
 kernel-devel-3.10.0-957.12.2.el7.x86_64.rpm
+protoc-3.14.0-linux-x86_64.zip

--- a/live-usb-creator/README.md
+++ b/live-usb-creator/README.md
@@ -12,14 +12,16 @@ Set the following files in place in the same directory as the `Vagrantfile`.
 * CodeSafe-linux64-dev-12.50.2.iso (2.6GB): supplied by the HSM vendor.
 * CentOS-7-x86_64-Everything-1908.iso (10G): `curl -O https://vault.centos.org/7.7.1908/isos/x86_64/CentOS-7-x86_64-Everything-1908.iso`
 * kernel-devel-3.10.0-957.12.2.el7.x86_64.rpm (17MB): `curl -L -O http://archive.kernel.org/centos-vault/centos/7.6.1810/updates/x86_64/Packages/kernel-devel-3.10.0-957.12.2.el7.x86_64.rpm`
+* protoc-3.14.0-linux-x86_64.zip (1.6MB): `curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v3.14.0/protoc-3.14.0-linux-x86_64.zip`
 
 Verify the following SHA256 sums:
 
 ```bash
-$ shasum -a 256 CodeSafe-linux64-dev-12.50.2.iso CentOS-7-x86_64-Everything-1908.iso kernel-devel-3.10.0-957.12.2.el7.x86_64.rpm
+$ shasum -a 256 CodeSafe-linux64-dev-12.50.2.iso CentOS-7-x86_64-Everything-1908.iso kernel-devel-3.10.0-957.12.2.el7.x86_64.rpm protoc-3.14.0-linux-x86_64.zip
 23ca2c5fc2476887926409bc69f19b772c99191b1e0cce1a3bace8d1e4488528  CodeSafe-linux64-dev-12.50.2.iso
 bd5e6ca18386e8a8e0b5a9e906297b5610095e375e4d02342f07f32022b13acf  CentOS-7-x86_64-Everything-1908.iso
 a27c718efb2acec969b20023ea517d06317b838714cb359e4a80e8995ac289fc  kernel-devel-3.10.0-957.12.2.el7.x86_64.rpm
+a2900100ef9cda17d9c0bbf6a3c3592e809f9842f2d9f0d50e3fba7f3fc864f0  protoc-3.14.0-linux-x86_64.zip
 ```
 
 The CentOS's GPG signature can also be verified to confirm the image has been signed by the CentOS team.

--- a/live-usb-creator/Vagrantfile
+++ b/live-usb-creator/Vagrantfile
@@ -62,7 +62,7 @@ Vagrant.configure("2") do |config|
                          'yum-config-manager --disable \* && ' \
                          "yum-config-manager --enable c7-media --setopt='c7-media.baseurl=file:///media/CentOS/' && " \
                          "rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 &&" \
-                         "yum swap -y -- install perl gcc binutils make perl bzip2 lorax anaconda patch grub2-efi-x64-modules" \
+                         "yum swap -y -- install perl gcc binutils make bzip2 lorax anaconda patch grub2-efi-x64-modules" \
                                     " -- localinstall #{kernel_devel_guest_tmp_path}", opts, &block)
         super
       end

--- a/live-usb-creator/build.sh
+++ b/live-usb-creator/build.sh
@@ -15,10 +15,12 @@ sudo cp /vagrant/patches/usr/share/lorax/live/efi.tmpl /usr/share/lorax/live/efi
 rm -rf /vagrant/live_scripts/.isotype_rel /vagrant/live_scripts/.isotype_dev
 if [ "$1" = "dev" ]; then
   BUILD_TYPE="Dev"
+  RHEL_KS=rhel7-livemedia-dev.ks
   cp /vagrant/live_scripts/install_nfast_tools_dev /vagrant/live_scripts/install_nfast_tools
   touch /vagrant/live_scripts/.isotype_dev
 elif [ "$1" = "release" ] || [ "$#" -eq 0 ]; then
   BUILD_TYPE="Rel"
+  RHEL_KS=rhel7-livemedia.ks
   cp /vagrant/live_scripts/install_nfast_tools_release /vagrant/live_scripts/install_nfast_tools
   touch /vagrant/live_scripts/.isotype_rel
 else
@@ -33,7 +35,7 @@ fi
 # livemedia-creator refuses to run if results_dir exists
 sudo rm -rf /tmp/build
 
-sudo livemedia-creator --logfile=/vagrant/livemedia-creator.log --make-iso --ks=/vagrant/rhel7-livemedia.ks --resultdir="/tmp/build" --no-virt --project="CentOS" --releasever="7.7.1908" --volid="CentOS 7 (1908) + nCipher ($BUILD_TYPE)"
+sudo livemedia-creator --logfile=/vagrant/livemedia-creator.log --make-iso --ks="/vagrant/${RHEL_KS}" --resultdir="/tmp/build" --no-virt --project="CentOS" --releasever="7.7.1908" --volid="CentOS 7 (1908) + nCipher ($BUILD_TYPE)"
 
 ###############################################################################
 # Copy ISO back to host

--- a/live-usb-creator/install_scripts/0_post_install_nochroot
+++ b/live-usb-creator/install_scripts/0_post_install_nochroot
@@ -65,4 +65,5 @@ cp /vagrant/syslinux-splash.png /mnt/sysimage/usr/share/anaconda/boot/syslinux-s
 
 mkdir -p /mnt/sysimage/data/app/subzero
 cp -r /vagrant/data_app_subzero/* /mnt/sysimage/data/app/subzero
-
+# pre-compiled protobuf compiler
+cp /vagrant/protoc-3.14.0-linux-x86_64.zip /mnt/sysimage/data/app/subzero

--- a/live-usb-creator/live_scripts/install_protoc
+++ b/live-usb-creator/live_scripts/install_protoc
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+###############################################################################
+# Install protobuf compiler image
+###############################################################################
+
+unzip -o /data/app/subzero/protoc-3.14.0-linux-x86_64.zip -d /usr bin/protoc
+unzip -o /data/app/subzero/protoc-3.14.0-linux-x86_64.zip -d /usr "include/*"
+rm -rf /data/app/subzero/protoc-3.14.0-linux-x86_64.zip

--- a/live-usb-creator/live_scripts/startup
+++ b/live-usb-creator/live_scripts/startup
@@ -3,6 +3,8 @@
 # /etc/rc.d/init.d/livesys calls out to this script (/usr/local/bin/startup), meaning it’s run on startup.
 # Note that it does NOT block a TTY/login/bash/etc., hence the nfast_block_shell utility script.
 
+/usr/local/bin/install_protoc
+
 /usr/local/bin/install_nfast_tools
 
 # now that NFast Tools have been installed, we touch /.nfast-configured, thus unblocking the nfast_block_shell utility script

--- a/live-usb-creator/rhel7-livemedia-dev.ks
+++ b/live-usb-creator/rhel7-livemedia-dev.ks
@@ -1,0 +1,374 @@
+#version=DEVEL
+sshpw --username=root --plaintext randOmStrinGhERE
+# Firewall configuration
+firewall --enabled --service=mdns
+# Use local CentOS media for installation
+url --url=file:///media/CentOS/
+
+#no X (GUI)
+skipx
+# Root password
+rootpw --plaintext removethispw
+# Network information
+network  --bootproto=dhcp --onboot=on --activate
+# System authorization information
+auth --useshadow --enablemd5
+# disable kdump (seems to fail anyways due to memory requirements?)
+%addon com_redhat_kdump --disable
+%end
+# System keyboard
+keyboard --xlayouts=us --vckeymap=us
+# System language
+lang en_US.UTF-8
+# SELinux configuration
+selinux --enforcing
+# Installation logging level
+logging --level=info
+# Shutdown after installation
+shutdown
+# System services
+services --disabled="network,sshd" --enabled="NetworkManager"
+# System timezone
+timezone  US/Eastern
+# System bootloader configuration
+bootloader --location=mbr
+# Clear the Master Boot Record
+zerombr
+# Partition clearing information
+clearpart --all
+# Disk partitioning information
+part biosboot --size=1
+part / --fstype="ext4" --size=5000
+part swap --size=1000
+
+%post
+# FIXME: it'd be better to get this installed from a package
+cat > /etc/rc.d/init.d/livesys << EOF
+#!/bin/bash
+#
+# live: Init script for live image
+#
+# chkconfig: 345 00 99
+# description: Init script for live image.
+
+. /etc/init.d/functions
+
+if ! strstr "\`cat /proc/cmdline\`" rd.live.image || [ "\$1" != "start" ]; then
+    exit 0
+fi
+
+if [ -e /.liveimg-configured ] ; then
+    configdone=1
+fi
+
+exists() {
+    which \$1 >/dev/null 2>&1 || return
+    \$*
+}
+
+touch /.liveimg-configured
+
+# mount live image
+if [ -b \`readlink -f /dev/live\` ]; then
+   mkdir -p /mnt/live
+   mount -o ro /dev/live /mnt/live 2>/dev/null || mount /dev/live /mnt/live
+fi
+
+livedir="LiveOS"
+for arg in \`cat /proc/cmdline\` ; do
+  if [ "\${arg##live_dir=}" != "\${arg}" ]; then
+    livedir=\${arg##live_dir=}
+    return
+  fi
+done
+
+# enable swaps unless requested otherwise
+swaps=\`blkid -t TYPE=swap -o device\`
+if ! strstr "\`cat /proc/cmdline\`" noswap && [ -n "\$swaps" ] ; then
+  for s in \$swaps ; do
+    action "Enabling swap partition \$s" swapon \$s
+  done
+fi
+if ! strstr "\`cat /proc/cmdline\`" noswap && [ -f /mnt/live/\${livedir}/swap.img ] ; then
+  action "Enabling swap file" swapon /mnt/live/\${livedir}/swap.img
+fi
+
+mountPersistentHome() {
+  # support label/uuid
+  if [ "\${homedev##LABEL=}" != "\${homedev}" -o "\${homedev##UUID=}" != "\${homedev}" ]; then
+    homedev=\`/sbin/blkid -o device -t "\$homedev"\`
+  fi
+
+  # if we're given a file rather than a blockdev, loopback it
+  if [ "\${homedev##mtd}" != "\${homedev}" ]; then
+    # mtd devs don't have a block device but get magic-mounted with -t jffs2
+    mountopts="-t jffs2"
+  elif [ ! -b "\$homedev" ]; then
+    loopdev=\`losetup -f\`
+    if [ "\${homedev##/mnt/live}" != "\${homedev}" ]; then
+      action "Remounting live store r/w" mount -o remount,rw /mnt/live
+    fi
+    losetup \$loopdev \$homedev
+    homedev=\$loopdev
+  fi
+
+  # if it's encrypted, we need to unlock it
+  if [ "\$(/sbin/blkid -s TYPE -o value \$homedev 2>/dev/null)" = "crypto_LUKS" ]; then
+    echo
+    echo "Setting up encrypted /home device"
+    plymouth ask-for-password --command="cryptsetup luksOpen \$homedev EncHome"
+    homedev=/dev/mapper/EncHome
+  fi
+
+  # and finally do the mount
+  mount \$mountopts \$homedev /home
+  # if we have /home under what's passed for persistent home, then
+  # we should make that the real /home.  useful for mtd device on olpc
+  if [ -d /home/home ]; then mount --bind /home/home /home ; fi
+  [ -x /sbin/restorecon ] && /sbin/restorecon /home
+  if [ -d /home/liveuser ]; then USERADDARGS="-M" ; fi
+}
+
+findPersistentHome() {
+  for arg in \`cat /proc/cmdline\` ; do
+    if [ "\${arg##persistenthome=}" != "\${arg}" ]; then
+      homedev=\${arg##persistenthome=}
+      return
+    fi
+  done
+}
+
+if strstr "\`cat /proc/cmdline\`" persistenthome= ; then
+  findPersistentHome
+elif [ -e /mnt/live/\${livedir}/home.img ]; then
+  homedev=/mnt/live/\${livedir}/home.img
+fi
+
+# if we have a persistent /home, then we want to go ahead and mount it
+if ! strstr "\`cat /proc/cmdline\`" nopersistenthome && [ -n "\$homedev" ] ; then
+  action "Mounting persistent /home" mountPersistentHome
+fi
+
+# make it so that we don't do writing to the overlay for things which
+# are just tmpdirs/caches
+mount -t tmpfs -o mode=0755 varcacheyum /var/cache/yum
+mount -t tmpfs tmp /tmp
+mount -t tmpfs vartmp /var/tmp
+[ -x /sbin/restorecon ] && /sbin/restorecon /var/cache/yum /tmp /var/tmp >/dev/null 2>&1
+
+if [ -n "\$configdone" ]; then
+  exit 0
+fi
+
+# add fedora user with no passwd
+action "Adding live user" useradd \$USERADDARGS -c "Live System User" liveuser
+passwd -d liveuser > /dev/null
+
+# turn off firstboot for livecd boots
+chkconfig --level 345 firstboot off 2>/dev/null
+# We made firstboot a native systemd service, so it can no longer be turned
+# off with chkconfig. It should be possible to turn it off with systemctl, but
+# that doesn't work right either. For now, this is good enough: the firstboot
+# service will start up, but this tells it not to run firstboot. I suspect the
+# other services 'disabled' below are not actually getting disabled properly,
+# with systemd, but we can look into that later. - AdamW 2010/08 F14Alpha
+echo "RUN_FIRSTBOOT=NO" > /etc/sysconfig/firstboot
+
+# don't start yum-updatesd for livecd boots
+chkconfig --level 345 yum-updatesd off 2>/dev/null
+
+# turn off mdmonitor by default
+chkconfig --level 345 mdmonitor off 2>/dev/null
+
+# turn off setroubleshoot on the live image to preserve resources
+chkconfig --level 345 setroubleshoot off 2>/dev/null
+
+# don't start cron/at as they tend to spawn things which are
+# disk intensive that are painful on a live image
+chkconfig --level 345 crond off 2>/dev/null
+chkconfig --level 345 atd off 2>/dev/null
+chkconfig --level 345 anacron off 2>/dev/null
+chkconfig --level 345 readahead_early off 2>/dev/null
+chkconfig --level 345 readahead_later off 2>/dev/null
+
+# Stopgap fix for RH #217966; should be fixed in HAL instead
+touch /media/.hal-mtab
+
+# workaround clock syncing on shutdown that we don't want (#297421)
+sed -i -e 's/hwclock/no-such-hwclock/g' /etc/rc.d/init.d/halt
+
+# and hack so that we eject the cd on shutdown if we're using a CD...
+if strstr "\`cat /proc/cmdline\`" CDLABEL= ; then
+  cat >> /sbin/halt.local << FOE
+#!/bin/bash
+# XXX: This often gets stuck during shutdown because /etc/init.d/halt
+#      (or something else still running) wants to read files from the block\
+#      device that was ejected.  Disable for now.  Bug #531924
+# we want to eject the cd on halt, but let's also try to avoid
+# io errors due to not being able to get files...
+#cat /sbin/halt > /dev/null
+#cat /sbin/reboot > /dev/null
+#/usr/sbin/eject -p -m \$(readlink -f /dev/live) >/dev/null 2>&1
+#echo "Please remove the CD from your drive and press Enter to finish restarting"
+#read -t 30 < /dev/console
+FOE
+chmod +x /sbin/halt.local
+fi
+
+EOF
+
+# bah, hal starts way too late
+cat > /etc/rc.d/init.d/livesys-late << EOF
+#!/bin/bash
+#
+# live: Late init script for live image
+#
+# chkconfig: 345 99 01
+# description: Late init script for live image.
+
+. /etc/init.d/functions
+
+if ! strstr "\`cat /proc/cmdline\`" rd.live.image || [ "\$1" != "start" ] || [ -e /.liveimg-late-configured ] ; then
+    exit 0
+fi
+
+exists() {
+    which \$1 >/dev/null 2>&1 || return
+    \$*
+}
+
+touch /.liveimg-late-configured
+
+# read some variables out of /proc/cmdline
+for o in \`cat /proc/cmdline\` ; do
+    case \$o in
+    ks=*)
+        ks="--kickstart=\${o#ks=}"
+        ;;
+    xdriver=*)
+        xdriver="\${o#xdriver=}"
+        ;;
+    esac
+done
+
+# if liveinst or textinst is given, start anaconda
+if strstr "\`cat /proc/cmdline\`" liveinst ; then
+   plymouth --quit
+   /usr/sbin/liveinst \$ks
+fi
+if strstr "\`cat /proc/cmdline\`" textinst ; then
+   plymouth --quit
+   /usr/sbin/liveinst --text \$ks
+fi
+
+# configure X, allowing user to override xdriver
+if [ -n "\$xdriver" ]; then
+   cat > /etc/X11/xorg.conf.d/00-xdriver.conf <<FOE
+Section "Device"
+	Identifier	"Videocard0"
+	Driver	"\$xdriver"
+EndSection
+FOE
+fi
+
+EOF
+
+chmod 755 /etc/rc.d/init.d/livesys
+/sbin/restorecon /etc/rc.d/init.d/livesys
+/sbin/chkconfig --add livesys
+
+chmod 755 /etc/rc.d/init.d/livesys-late
+/sbin/restorecon /etc/rc.d/init.d/livesys-late
+/sbin/chkconfig --add livesys-late
+
+# work around for poor key import UI in PackageKit
+rm -f /var/lib/rpm/__db*
+rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+echo "Packages within this LiveCD"
+rpm -qa
+
+# go ahead and pre-make the man -k cache (#455968)
+/usr/bin/mandb
+
+# make sure there aren't core files lying around
+rm -f /core*
+
+# convince readahead not to collect
+rm -f /.readahead_collect
+touch /var/lib/readahead/early.sorted
+
+# Remove random-seed
+rm /var/lib/systemd/random-seed
+%end
+
+%post
+# Remove root password
+passwd -d root > /dev/null
+
+# fstab from the install won't match anything. remove it and let dracut
+# handle mounting.
+cat /dev/null > /etc/fstab
+
+%end
+
+%post --nochroot
+/vagrant/install_scripts/0_post_install_nochroot
+cp /vagrant/install_scripts/1_post_install_chroot /mnt/sysimage/tmp/
+
+for scriptfile in $(find /vagrant/live_scripts/ ! -path /vagrant/live_scripts/ ! -path /vagrant/live_scripts/README.md); do
+  cp $scriptfile /mnt/sysimage/usr/local/bin/
+done
+%end
+
+%post
+cat >> /etc/rc.d/init.d/livesys << EOF
+/usr/local/bin/startup
+EOF
+
+/tmp/1_post_install_chroot
+rm /tmp/1_post_install_chroot
+%end
+
+%packages --excludedocs
+# Packages needed by anaconda, but not directly required.
+# Includes all of the grub2 and shim packages needed, except
+# for the grub2-efi-*-cdboot package
+@anaconda-tools --optional
+@core
+-iwl*firmware
+anaconda
+isomd5sum
+kernel
+memtest86+
+syslinux
+-dracut-config-rescue
+
+# This package is needed to boot the iso on UEFI
+grub2-efi-*-cdboot
+grub2-efi-ia32
+
+# Java 8
+java-1.8.0-openjdk
+java-1.8.0-openjdk-devel
+
+# nCipher stuff
+gcc
+kernel-devel
+opensc
+pciutils
+
+# subzero development tools
+gcc-c++
+binutils
+git
+maven
+autoconf
+automake
+cmake
+libtool
+make
+vim
+vim-common
+python3
+protobuf-python
+%end


### PR DESCRIPTION
This is for the dev-flabored ISO to be more readily used for subzero development.

Tools such as maven, cmake, python3 are added.

We also install a pre-compiled version of protobuf compiler because Centos 7 does not have a version of protoc that works for us.

With this change, a subzero developer can build the Java components directly out of the ISO. To build the subzero core, `python3-protobuf` and `protobuf` need to be pip installed.