### PR TITLE
Bugfix: print out master seed for debugging, using the right count

### DIFF
--- a/core/src/dev/protection.c
+++ b/core/src/dev/protection.c
@@ -158,8 +158,8 @@ Result expose_wallet(EncryptedMasterSeed *encrypted_master_seed,
     return Result_EXPOSE_WALLET_UNEXPECTED_MASTER_SEED_LEN_FAILURE;
   }
 
-  printf("master_seed: ");
-  for (unsigned int i = 0; i < r; i++) {
+  DEBUG_("master_seed: ");
+  for (unsigned int i = 0; i < master_seed_len; i++) {
     DEBUG_("%02x", master_seed[i]);
   }
   DEBUG_("\n");

--- a/core/src/ncipher/protection.c
+++ b/core/src/ncipher/protection.c
@@ -152,8 +152,8 @@ Result expose_wallet(EncryptedMasterSeed *encrypted_master_seed,
     return Result_EXPOSE_WALLET_UNEXPECTED_MASTER_SEED_LEN_FAILURE;
   }
 
-  printf("master_seed: ");
-  for (unsigned int i = 0; i < r; i++) {
+  DEBUG_("master_seed: ");
+  for (unsigned int i = 0; i < master_seed_len; i++) {
     DEBUG_("%02x", master_seed[i]);
   }
   DEBUG_("\n");


### PR DESCRIPTION
Use master_seed_len as the count. Note that DEBUG_ only prints when we are with TEST_NET.