### PR TITLE
Resolve a few clang static analyzer warnings

### DIFF
--- a/core/include/strlcpy.h
+++ b/core/include/strlcpy.h
@@ -1,0 +1,50 @@
+#pragma once
+/*
+ * Copyright (c) 1998, 2015 Todd C. Miller <millert@openbsd.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/* Source: https://github.com/openbsd/src/blob/master/lib/libc/string/strlcpy.c */
+
+#include <sys/types.h>
+
+/*
+ * Copy string src to buffer dst of size dsize.  At most dsize-1
+ * chars will be copied.  Always NUL terminates (unless dsize == 0).
+ * Returns strlen(src); if retval >= dsize, truncation occurred.
+ */
+static inline size_t
+subzero_strlcpy(char *dst, const char *src, size_t dsize)
+{
+	const char *osrc = src;
+	size_t nleft = dsize;
+
+	/* Copy as many bytes as will fit. */
+	if (nleft != 0) {
+		while (--nleft != 0) {
+			if ((*dst++ = *src++) == '\0')
+				break;
+		}
+	}
+
+	/* Not enough room in dst, add NUL and traverse rest of src. */
+	if (nleft == 0) {
+		if (dsize != 0)
+			*dst = '\0';		/* NUL-terminate dst */
+		while (*src++)
+			;
+	}
+
+	return(src - osrc - 1);	/* count does not include NUL */
+}

--- a/core/src/checks/verify_protect_pubkey.c
+++ b/core/src/checks/verify_protect_pubkey.c
@@ -2,13 +2,14 @@
 #include "config.h"
 #include "log.h"
 #include "protection.h"
+#include "strlcpy.h"
 
 int verify_protect_pubkey(void) {
   EncryptedPubKey temp = EncryptedPubKey_init_default;
   char buffer1[XPUB_SIZE] =
       "xpub661MyMwAqRbcGw6rpZ6SYUfFk6Z5YX216YRXnhuB6UcdwuVe4XUKKiPg";
   char buffer2[XPUB_SIZE];
-  strcpy(buffer2, buffer1);
+  subzero_strlcpy(buffer2, buffer1, sizeof(buffer2));
 
   char buffer3[XPUB_SIZE];
 

--- a/core/src/finalize_wallet.c
+++ b/core/src/finalize_wallet.c
@@ -7,6 +7,7 @@
 #include "log.h"
 #include "protection.h"
 #include "rpc.h"
+#include "strlcpy.h"
 
 Result
 handle_finalize_wallet(InternalCommandRequest_FinalizeWalletRequest *in,
@@ -87,7 +88,11 @@ handle_finalize_wallet(InternalCommandRequest_FinalizeWalletRequest *in,
 
   static_assert(sizeof(out->pub_key.bytes) == XPUB_SIZE,
                 "misconfigured pub_key max size");
-  strcpy((char *)out->pub_key.bytes, pub_keys[i]);
+  if (subzero_strlcpy((char *)out->pub_key.bytes, pub_keys[i],
+    sizeof(out->pub_key.bytes)) >= sizeof(out->pub_key.bytes)) {
+      ERROR("pub_key %d is too long", i);
+      return Result_UNKNOWN_INTERNAL_FAILURE;
+    }
   out->pub_key.size = (pb_size_t)strlen(pub_keys[i]);
 
   // TODO: figure out pub_keys_hash story

--- a/core/src/no_rollback.c
+++ b/core/src/no_rollback.c
@@ -85,7 +85,7 @@ Result no_rollback_write_version(const char* filename, uint32_t magic, uint32_t 
   DEBUG("in no_rollback_write");
 
   char buf[VERSION_SIZE];
-  bzero(buf, VERSION_SIZE);
+  memset(buf, 0, VERSION_SIZE);
   snprintf(buf, sizeof(buf), "%d-%d", magic, version);
   return no_rollback_write(filename, buf);
 }

--- a/core/src/no_rollback.c
+++ b/core/src/no_rollback.c
@@ -1,3 +1,5 @@
+#include <stdlib.h> /* strtoul */
+#include <inttypes.h>
 #include "no_rollback.h"
 #include "log.h"
 
@@ -27,8 +29,32 @@ Result no_rollback_check(const char* filename, bool allow_upgrade, uint32_t expe
     return r;
   }
 
-  uint32_t magic, version, matches;
-  matches = sscanf(buf, "%u-%u", &magic, &version);
+  unsigned long magic = 0; // 0 is not a valid magic number
+  unsigned long version = 0; // 0 is not a valid version number
+  int matches = 0;
+  char *endptr = NULL;
+
+  magic = strtoul(buf, &endptr, 10);
+  if (magic == 0) {
+    ERROR("%s: invalid magic failure", __func__);
+    return Result_NO_ROLLBACK_INVALID_FORMAT;
+  }
+  matches++;
+
+  if (endptr == NULL || *endptr != '-') {
+    ERROR("%s: invalid format failure", __func__);
+    return Result_NO_ROLLBACK_INVALID_FORMAT;
+  }
+
+  endptr++;
+  version = strtoul(endptr, NULL, 10);
+  if (version == 0 || version > UINT32_MAX) {
+    ERROR("%s: invalid version failure", __func__);
+    return Result_NO_ROLLBACK_INVALID_FORMAT;
+  }
+  matches++;
+
+  // matches should always be 2. Check anyway.
   if (matches != 2) {
     ERROR("no_rollback_check: invalid format failure");
     return Result_NO_ROLLBACK_INVALID_FORMAT;
@@ -39,7 +65,7 @@ Result no_rollback_check(const char* filename, bool allow_upgrade, uint32_t expe
   }
 
   if (allow_upgrade && (version < expected_version)) {
-    INFO("no_rollback_check: bumping version from %d to %d", version, expected_version);
+    INFO("no_rollback_check: bumping version from %"PRIu32" to %"PRIu32, (uint32_t) version, expected_version);
     r = no_rollback_write_version(filename, expected_magic, expected_version);
     if (r != Result_SUCCESS) {
       return r;


### PR DESCRIPTION
    Add strlcpy from OpenBSD
    Add subzero_strlcpy as a static inline function in strlcpy.h, so that we will have a safer alternative to strcpy.
    Adding strlcpy in a custom header file is the easiest portable approach for osx, linux and codesafe targets.

    Replace strcpy with a safter subzero_strlcpy
    This resolves clang static analyzer warning on the use of 'strcpy'. Although strcpy can be used safely, it's nevertheless a good idea to use a safer alternative.

    Use strtoul in the place of sscanf
    This is to resolve a clang static analyzer warning regarding deprecated API. We also take the opportunity to add more checks on input values.