### PR TITLE
Run clang static analyzer in CI

### DIFF
--- a/.github/workflows/clang-static-analysis.yml
+++ b/.github/workflows/clang-static-analysis.yml
@@ -12,7 +12,7 @@ on:
     - cron: '0 2 * * *'
 
 jobs:
-  analyze:
+  sacheck:
     name: "Clang Static Analysis"
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/clang-static-analysis.yml
+++ b/.github/workflows/clang-static-analysis.yml
@@ -1,0 +1,56 @@
+# Static analysis of subzero CORE via clang static analyzer
+name: "Clang Static Analysis"
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [master]
+  schedule:
+    # Daily at 2am
+    - cron: '0 2 * * *'
+
+jobs:
+  analyze:
+    name: "Clang Static Analysis"
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -euxo pipefail {0}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.9]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with:
+        # We must fetch at least the immediate parents so that if this is
+        # a pull request then we can checkout the head.
+        fetch-depth: 2
+        submodules: 'recursive'
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Display Python version
+      run: |
+        python -c "import sys; print(sys.version)"
+
+    - name: Install build dependencies
+      run: scripts/ubuntu_install_protobuf.sh
+
+    - name: Install clang tools
+      run: |
+        sudo apt-get update
+        sudo apt-get install clang-tools-10 -y
+        sudo ln -sf /usr/bin/clang-check-10 /usr/bin/clang-check
+
+    # Run static analysis
+    - name: Run clang static analysis
+      run: scripts/sa_check_core.sh

--- a/.github/workflows/signtx-test.yml
+++ b/.github/workflows/signtx-test.yml
@@ -12,8 +12,8 @@ on:
     - cron: '0 1 * * *'
 
 jobs:
-  analyze:
-    name: Analyze
+  signtx-test:
+    name: "SignTx Test"
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/scripts/build_core.sh
+++ b/scripts/build_core.sh
@@ -5,5 +5,5 @@ set -euxo pipefail
 cd "$(dirname $0)"/..
 mkdir -p core/build
 cd core/build
-TARGET=dev CURRENCY=btc-testnet cmake ../
+TARGET=dev CURRENCY=btc-testnet cmake ../ -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 make

--- a/scripts/sa_check_core.sh
+++ b/scripts/sa_check_core.sh
@@ -7,11 +7,11 @@ set -euxo pipefail
 
 echo "Static analysis through clang static analyzer"
 EXCLUDE_PATH_PATTERN="\/external-crypto\/\|\/trezor-crypto\/"
-SUBZERO_ROOT=$(cd "$(dirname "$0")"; pwd -P)
+SUBZERO_ROOT=$(cd "$(dirname "$0")"; pwd -P)/..
 
-${SUBZERO_ROOT}/build_core.sh
+${SUBZERO_ROOT}/scripts/build_core.sh
 
-COMPILE_DB_DIR="${SUBZERO_ROOT}/../core/build"
+COMPILE_DB_DIR="${SUBZERO_ROOT}/core/build"
 COMPILE_DB="${COMPILE_DB_DIR}/compile_commands.json"
 if [ ! -f "${COMPILE_DB}" ]; then
     exit 1

--- a/scripts/sa_check_core.sh
+++ b/scripts/sa_check_core.sh
@@ -8,10 +8,8 @@ set -euxo pipefail
 echo "Static analysis through clang static analyzer"
 EXCLUDE_PATH_PATTERN="\/external-crypto\/\|\/trezor-crypto\/"
 SUBZERO_ROOT=$(cd "$(dirname "$0")"; pwd -P)
-cd "$(dirname $0)"/..
-mkdir -p core/build
-cd core/build
-TARGET=dev CURRENCY=btc-testnet cmake ../ -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+
+${SUBZERO_ROOT}/build_core.sh
 
 COMPILE_DB_DIR="${SUBZERO_ROOT}/../core/build"
 COMPILE_DB="${COMPILE_DB_DIR}/compile_commands.json"


### PR DESCRIPTION
    Run clang static analyzer in CI
    Set up GHA workflow for running clang static analyzer in CI.
    We also take the opportunity to improve scripts and fix minor bugs.

    Use better names for workflow jobs.
    Make some cosmetic but worthy changes in GHA workflow job names for clang static analysis and signtx test.