### PR TITLE
Documentation format improvements

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,7 @@ the caveat that the code is currently only useful if you have the exact same har
 code more modular over time, as long as the broader community shows interest to implement support for additional
 hardware vendors.
 
-<img src="map.svg">
+![Map](./map.svg)
 
 _A multi-party signing ceremony is needed to unlock funds._
 

--- a/docs/regression-testing-howto.md
+++ b/docs/regression-testing-howto.md
@@ -10,98 +10,98 @@ the steps for `TARGET=dev`, for presentation simplicity.*
 
 ## How to run regression tests
 
-1. Build subzero code (core, development server and user interface) as
-instructed in [subzero
-documentation](https://subzero.readthedocs.io/en/master/running_without_hsm/).
-2. Start subzero core in a terminal
+- Build subzero code (core, development server and user interface) as
+instructed in [subzero documentation](./running_without_hsm.md).
 
-   ```no-highlight
-   # under subzero repository directory root
-   ./core/build/subzero
-   ```
+- Start subzero core in a terminal
 
-3. In another terminal, invoke subzero GUI with option `--signtx-test`
+```bash
+# under subzero repository directory root
+./core/build/subzero
+```
 
-   ```no-highlight
-   # under subzero repository directory root
-   ./java/gui/target/gui-1.0.0-SNAPSHOT-shaded.jar --signtx-test
-   ```
+- In another terminal, invoke subzero GUI with option `--signtx-test`
+
+```bash
+# under subzero repository directory root
+./java/gui/target/gui-1.0.0-SNAPSHOT-shaded.jar --signtx-test
+```
 
 ## How to create test vectors
 
 An outline of the test vector creation process is as follows.
 
-1. Run subzero components locally exactly as described in [subzero
+- Run subzero components locally exactly as described in [subzero
 documentation](https://subzero.readthedocs.io/en/master/running_without_hsm/).
 Put the follow content in `/data/app/subzero/wallets/subzero-1492.wallet`
 
-   ```no-highlight
-   {"currency":"TEST_NET","encrypted_master_seed":{"encrypted_master_seed":"ioBg3WF2BntMnGae6PyWbp1VG4r446PUYVZnt1BzOOVQzHy3XeaqmBXS6tMbE9fsB0sR+Vi9xPgJcayN2uJsJNjEw7S77h9oUUpu0zWrYvl6iRAI4fcezOxbRcc="},"encrypted_pub_keys":[{"encrypted_pub_key":"OytXbV6n2L0l50yLegnaP6ea9jRDfFM0I6J/tJQzvnc2+E2Bleqvh4ZaIoTd7Nm6j9XRag1WYni/K0uoek/0rLnLNGZbrrQLNt5lkfTTcMZ72mEKTRkvRWbJwd8H+p86GLqSqgvofDSE5E5EkgYGhIGSkFy8dLpXK4jpYxAQGrIQ2tNeXKKw2nNPOQ=="},{"encrypted_pub_key":"YxgmbmaiwGON1uHpp6cp7sWxMNNJYbX4tqtEJwbOYqfKWW9k56V/uguQrliIwaG2X7ca6VJ01YQiiMdJciQzb3w182R/HsGiYYdMuHP0PNjVk9ScYby38ofTUfjW8ihUFFjM6FSs7WzZAFCuQ04bNNATuGfdXQK8pgoCHKWKTJ2c3alaZvIauwzkfQ=="},{"encrypted_pub_key":"i36ne27C7pv1psRFttz3oNBVZVwgh/t6sQO3DUDfb6Edw3GvDAea3oPQ3Fm5No3JBWp5/SARPva29lPdi4X4mz+qde2nPYMvIJtW0ndAUGU2kw9dhzVY/FZ8XGnIH33otuKE2i+HxOYwxk6+EqS1WEoWEqRe2LO8h1DTg9GsYzzTyjSj2OKIOGc02A=="},{"encrypted_pub_key":"s/1O2nYnApJd+Mlc10rvGsMghE8AmhfIBXDBW52GBrjML07IVF3pZsgPKt4mLpsf2aUcHYn4P276jrdN1rCCxlkz1haxZawNOD0RUdocg5/h6GjaeOqJVxI6hgD3xqJRT+8e2OjVLwJWSmwbX2ckeKz+u76bFNxiCP2g+UCT94s8amrAeQTLXwF9lg=="}]}
-   ```
+```no-highlight
+{"currency":"TEST_NET","encrypted_master_seed":{"encrypted_master_seed":"ioBg3WF2BntMnGae6PyWbp1VG4r446PUYVZnt1BzOOVQzHy3XeaqmBXS6tMbE9fsB0sR+Vi9xPgJcayN2uJsJNjEw7S77h9oUUpu0zWrYvl6iRAI4fcezOxbRcc="},"encrypted_pub_keys":[{"encrypted_pub_key":"OytXbV6n2L0l50yLegnaP6ea9jRDfFM0I6J/tJQzvnc2+E2Bleqvh4ZaIoTd7Nm6j9XRag1WYni/K0uoek/0rLnLNGZbrrQLNt5lkfTTcMZ72mEKTRkvRWbJwd8H+p86GLqSqgvofDSE5E5EkgYGhIGSkFy8dLpXK4jpYxAQGrIQ2tNeXKKw2nNPOQ=="},{"encrypted_pub_key":"YxgmbmaiwGON1uHpp6cp7sWxMNNJYbX4tqtEJwbOYqfKWW9k56V/uguQrliIwaG2X7ca6VJ01YQiiMdJciQzb3w182R/HsGiYYdMuHP0PNjVk9ScYby38ofTUfjW8ihUFFjM6FSs7WzZAFCuQ04bNNATuGfdXQK8pgoCHKWKTJ2c3alaZvIauwzkfQ=="},{"encrypted_pub_key":"i36ne27C7pv1psRFttz3oNBVZVwgh/t6sQO3DUDfb6Edw3GvDAea3oPQ3Fm5No3JBWp5/SARPva29lPdi4X4mz+qde2nPYMvIJtW0ndAUGU2kw9dhzVY/FZ8XGnIH33otuKE2i+HxOYwxk6+EqS1WEoWEqRe2LO8h1DTg9GsYzzTyjSj2OKIOGc02A=="},{"encrypted_pub_key":"s/1O2nYnApJd+Mlc10rvGsMghE8AmhfIBXDBW52GBrjML07IVF3pZsgPKt4mLpsf2aUcHYn4P276jrdN1rCCxlkz1haxZawNOD0RUdocg5/h6GjaeOqJVxI6hgD3xqJRT+8e2OjVLwJWSmwbX2ckeKz+u76bFNxiCP2g+UCT94s8amrAeQTLXwF9lg=="}]}
+```
 
-2. Start subzero core and the development server as normal
+- Start subzero core and the development server as normal
 
-   In one terminal
+  In one terminal
 
-   ```no-highlight
-   # under subzero repository directory root
-   ./core/build/subzero
-   ```
+```bash
+# under subzero repository directory root
+./core/build/subzero
+```
 
-   In another terminal
+  In another terminal
 
-   ```no-highlight
-   # under subzero repository directory root
-   ./java/server/target/server-1.0.0-SNAPSHOT.jar server
-   ```
+```bash
+# under subzero repository directory root
+./java/server/target/server-1.0.0-SNAPSHOT.jar server
+```
 
-3. Run python script `txsign_testcase_expect_scrypt_gen.py` to generate an
+- Run python script `txsign_testcase_expect_scrypt_gen.py` to generate an
 [expect script](https://core.tcl-lang.org/expect/index) that will later be
 used to generate test vector files.
 
-   ```no-highlight
-   # under subzero repository directory root
-   python3 ./utils/txsign_testcase_expect_script_gen.py > /tmp/subzero_expect.sh
-   chmod +x /tmp/subzero_expect.sh
-   ```
+```bash
+# under subzero repository directory root
+python3 ./utils/txsign_testcase_expect_script_gen.py > /tmp/subzero_expect.sh
+chmod +x /tmp/subzero_expect.sh
+```
 
-   Under the hood in `txsign_testcase_expect_script_gen.py`:
+Under the hood in `txsign_testcase_expect_script_gen.py`:
 
-   - Generate 255 (17x5x3) test vectors in JSON based on a fixed RNG seed
-   (1492), as well as the number of inputs (MAX 17), the number of outputs
-   (MAX 5) and the size (LARGE, MEDIUM or SMALL) of satoshi amount in a
-   transaction to be signed.
-   - POST the auto-generated JSON payloads in HTTP requests to the local
-   development server's `generate-qr-code/sign-tx-request` API endpoint to
-   retrieve base64-encoded, proto-buffer-formatted sign-transaction requests
-   for the GUI to send to subzero core later.
-   - Construct an expect script using the base64-encoded requests to
-   interact with the GUI automatically, and output the expect script to
-   STDOUT.
+>   - Generate 255 (17x5x3) test vectors in JSON based on a fixed RNG seed
+>   (1492), as well as the number of inputs (MAX 17), the number of outputs
+>   (MAX 5) and the size (LARGE, MEDIUM or SMALL) of satoshi amount in a
+>   transaction to be signed.
+>   - POST the auto-generated JSON payloads in HTTP requests to the local
+>   development server's `generate-qr-code/sign-tx-request` API endpoint to
+>   retrieve base64-encoded, proto-buffer-formatted sign-transaction requests
+>   for the GUI to send to subzero core later.
+>   - Construct an expect script using the base64-encoded requests to
+>   interact with the GUI automatically, and output the expect script to
+>   STDOUT.
 
-4. Run the expect script generated in the last step to create a log file
+- Run the expect script generated in the last step to create a log file
 `expect_subzero.log`.
 
-   ```no-highlight
-   # under subzero repository directory root
-   # remove existing log file, if any
-   rm expect_subzero.log
-   # invoke expect script, pointing to the GUI jar
-   /tmp/subzero_expect.sh ./java/gui/target/gui-1.0.0-SNAPSHOT-shaded.jar
-   # 'expect_subzero.log' should show up below
-   ls -l expect_subzero.log
-   ```
+```bash
+# under subzero repository directory root
+# remove existing log file, if any
+rm expect_subzero.log
+# invoke expect script, pointing to the GUI jar
+/tmp/subzero_expect.sh ./java/gui/target/gui-1.0.0-SNAPSHOT-shaded.jar
+# 'expect_subzero.log' should show up below
+ls -l expect_subzero.log
+```
 
-5. Run python script `txsign_testcase_from_expect_log.py` to parse the
+- Run python script `txsign_testcase_from_expect_log.py` to parse the
 expect script log, and generate test vector files in `/tmp/out_dir`
 
-   ```no-highlight
-   # under subzero repository directory root
-   mkdir -p /tmp/out_dir
-   python3 utils/txsign_testcase_from_expect_log.py -i ./expect_subzero.log -o /tmp/out_dir
-   # test vector files should now show up
-   ls -l /tmp/out_dir
-   ```
+```bash
+# under subzero repository directory root
+mkdir -p /tmp/out_dir
+python3 utils/txsign_testcase_from_expect_log.py -i ./expect_subzero.log -o /tmp/out_dir
+# test vector files should now show up
+ls -l /tmp/out_dir
+```
 
 Here is the content of a sample test vector (`cat /tmp/out_dir/valid-0000`).
 
@@ -119,22 +119,22 @@ the development server's "Pretty print" utility.
 
 - How to create new test vectors. There are multiple ways
 
-  - Rotate the RNG seed in `txsign_testcase_expect_script_gen.py` to
-  generate another set of 255 test vectors
-  - Hack up `txsign_testcase_expect_script_gen.py` to add new test vector
-  generation logic
-  - Hand craft test transactions in JSON, and convert them into test vectors
-  following a procedure similar how `txsign_testcase_expect_script_gen.py`
-  does it, as described in the previous section
+>  - Rotate the RNG seed in `txsign_testcase_expect_script_gen.py` to
+>  generate another set of 255 test vectors
+>  - Hack up `txsign_testcase_expect_script_gen.py` to add new test vector
+>  generation logic
+>  - Hand craft test transactions in JSON, and convert them into test vectors
+>  following a procedure similar how `txsign_testcase_expect_script_gen.py`
+>  does it, as described in the previous section
 
 - How to make test vectors available for subzero GUI
 
-  - Copy all test vector files to subzero's source directory
-  `java/gui/src/main/resources/txsign-testvectors/`. Prefix valid (positive)
-  test vector file names with "valid-" (e.g., "valid-0042"), and prefix invalid
-  (negative) test vector file names with "invalid".
-  - Rebuild the GUI jar, and run the regression test
-  - Check the test vectors into the subzero repository
+>  - Copy all test vector files to subzero's source directory
+>  `java/gui/src/main/resources/txsign-testvectors/`. Prefix valid (positive)
+>  test vector file names with "valid-" (e.g., "valid-0042"), and prefix invalid
+>  (negative) test vector file names with "invalid".
+>  - Rebuild the GUI jar, and run the regression test
+>  - Check the test vectors into the subzero repository
 
 ## A few words on the design of this testing approach
 

--- a/docs/running_without_hsm.md
+++ b/docs/running_without_hsm.md
@@ -79,7 +79,8 @@ See also [sample output](core_sample_output.md).
     ./subzero/java/gui/target/gui-1.0.0-SNAPSHOT-shaded.jar
 
 Your environment should look as following (from top left, going clockwise): the GUI, a web browser, and a Terminal.
-<img src="../dev_setup.png">
+
+![Environment layout](./dev_setup.png)
 
 ## Creating a wallet and signing your first transaction
 
@@ -87,20 +88,21 @@ By default, Subzero is configured to work with 2-of-4 signatures. Creating a wal
 initialization and 4 finalization steps. Broadcasting a transaction will require 2 signatures.
 
 ### Initialization
+
 On the web browser, click on "generate QR code" under Initialize a wallet. Unless if you set a wallet id, the QR code
 should be "EAAaAA==".
 
-<img src="../init_wallet_dev_server.png">
+![Init wallet: dev server](./init_wallet_dev_server.png)
 
 You can paste this code in the GUI, which will change the GUI to the approval step. note: the GUI currently does not
 support clipboard operations. You can instead use the Terminal tab to copy-paste data.
 
-<img src="../init_wallet_gui.png">
+![Init wallet: GUI](./init_wallet_gui.png)
 
 Type "yes" + [enter] to continue. A QR code is displayed, but you can also copy the data from the Terminal. You will
 want to save this response in TextEdit. In our case, the response was `CnMKcQpv3trfyO6S55vO5PLtkpjakvPNzdOb+PLe0P3O5sft4tzb55Lp2tLd5N7Fydjs4MPZ8szcn5Lkm53dyc+ewcWSweDF2snP39ub/fny2v/v7ODI8uzA0M7+/8/8meDD0M7znO3vx+ub7+aS3Z3O+sDy`. Since this response contains ciphertext, the data will be different each time.
 
-<img src="../init_wallet_gui_done.png">
+![Init wallet: GUI done](./init_wallet_gui_done.png)
 
 Before you can repeat the wallet initialization process 3 more times, you need to move the wallet file out of the way:
 
@@ -111,10 +113,11 @@ Before you can repeat the wallet initialization process 3 more times, you need t
 
 Once you are done initializing the 4 shares, you'll have 4 files in /data/app/subzero/wallets/initialized:
 
-<img src="../init_wallet_initialized.png">
+![Init wallet: 4 shares](./init_wallet_initialized.png)
 
 And 4 responses in TextEdit:
-<img src="../init_wallet_text_edit.png">
+
+![Init wallet: 4 responses](./init_wallet_text_edit.png)
 
 ### Finalization
 
@@ -131,18 +134,18 @@ fyO6T88SYxOzN0P3mwpP5ktnO8Oj97/r+3uLd0uz//5/pyPLd05KTw9/L5/Pk+ezy+dCY2sPo++SemMD
 Tp///cx9DD/ujF4uDr2vrN0O3C2N3F086S8ND42+ft2cPr0/r5
 ```
 
-<img src="../finalize_wallet_web.png">
+![Finalize wallet: dev server ](./finalize_wallet_web.png)
 
 You can now finalize each wallet file. You will have to, one-by-one, copy wallet files from /data/app/subzero/wallets/initialized
 to /data/app/subzero/wallets/ and move the result to /data/app/subzero/wallets/finalized/.
 
     mv -n initialized/subzero-0.wallet-1 subzero-0.wallet
 
-<img src="../finalize_wallet_gui.png">
+![Finalize wallet: GUI](./finalize_wallet_gui.png)
 
 Type "yes" + [enter] to continue. Again, make sure you record each response. Our response was `EnEKb3RwdWJEOE0xZE5YRzgycDhZZ2d5MVJYdHpXZExtR0h2cU04Q3B4d050b2NyRkppc1hmdjU4TjE3d2NlNGtvOGtKb3BjZXVxMVdTWHBVRUZKYlhGanpkVFVlVjNKaXpkWTZHRW1BMUVMOHc3ZFBqWA==`.
 
-<img src="../finalize_wallet_gui_done.png">
+![Finalize wallet: GUI done](./finalize_wallet_gui_done.png)
 
 Move the wallet file out of the way and finalize the remaining 3 shares.
 
@@ -150,10 +153,11 @@ Move the wallet file out of the way and finalize the remaining 3 shares.
 
 Once you are done finalizing the 4 shares, you'll have 4 files in /data/app/subzero/wallets/finalized:
 
-<img src="../finalize_wallet_finalized.png">
+![Finalize wallet: Finalized](./finalize_wallet_finalized.png)
 
 And 4 more responses in TextEdit:
-<img src="../finalize_wallet_text_edit.png">
+
+![Finalize wallet: 4 responses](./finalize_wallet_text_edit.png)
 
 ### Reveal wallet xpubs
 
@@ -161,14 +165,14 @@ Using the 4 responses from the finalization step and the web browser, you can ge
 (`xpub` prefix for mainnet and `tpub` prefix for testnet). These public keys can be used to derive addresses and send
 funds to the cold wallet.
 
-<img src="../xpubs.png">
+![xpubs](./xpubs.png)
 
 ### Derive an address and send funds
 
 Using the same 4 responses from the finalization step and the web browser, you can get addresses. Let's derive the
 first non-change address. In our case, we get `2NF3qdAFLNTvC8C7kqbccndZzqU22uFAr8Z`.
 
-<img src="../derive_wallet_address.png">
+![Derive wallet address](./derive_wallet_address.png)
 
 We can send funds to this address and then use our wallet shares to sign a transaction which moves the funds out. For testnet addresses, we can use
 a [faucet](https://coinfaucet.eu/en/btc-testnet/), which is a free service available to Bitcoin developers to get testnet coins.
@@ -183,13 +187,13 @@ and send all the funds (minus the fee) to the gateway.
 
 Using the web browser, we get the following signing request `EAAqTQovCiAbDUIgtchXulYyyEGL9KseDnkTwZzXuWfuVMZv5Wb9zRABGLTdpAQiBBAAGAASDQiU0J4EEAIaBBAAGAAYACIAKQAAAAAAAAAA`.
 
-<img src="../first_transaction.png">
+![First transaction](./first_transaction.png)
 
 We'll need to use any two wallet shares to sign this transaction.
 
     mv -n finalized/subzero-0.wallet-1 subzero-0.wallet
 
-<img src="../sign_tx_gui.png">
+![SignTx GUI](./sign_tx_gui.png)
 
 Resulting in a signing response. Repeat the process with another wallet share to get two responses (our threshold).
 
@@ -202,7 +206,7 @@ Gm0KawpHMEUCIQDBfIptUIBoz0dP0xvOvzPd4VB0FXLYmsrfk52u8d3U5wIgbiEFEK5EWmunEiC/bh6f
 
 Use the web browser to merge these signatures into a transaction.
 
-<img src="../final_transaction.png">
+![Final transaction](./final_transaction.png)
 
 Our final transaction is:
 

--- a/docs/signing_ceremony.md
+++ b/docs/signing_ceremony.md
@@ -23,4 +23,4 @@ transaction is broadcasted
 end note
 -->
 
-<img src="../signing_ceremony.png">
+![Signing ceremony](./signing_ceremony.png)

--- a/docs/wallet_initialization.md
+++ b/docs/wallet_initialization.md
@@ -27,7 +27,7 @@ Java UI -> Operator: InitWalletResponse (QR code displayed)
 Operator -> Coordinator Service: InitWalletResponse (QR code scanned)
 -->
 
-<img src="../init_wallet.png">
+![Init wallet](./init_wallet.png)
 _Above process takes place once per location_
 
 By encrypting the xpub, we prevent the operators who are participating in the multi-party ceremony from being able to
@@ -57,7 +57,7 @@ Java UI -> Operator: FinalizeWalletResponse (QR code displayed)
 Operator -> Coordinator Service: FinalizeWalletResponse (QR code scanned)
 -->
 
-<img src="../finalize_wallet.png">
+[Finalize wallet](./finalize_wallet.png)
 _Above process also takes place once per location_
 
 Once every location has finalized their wallet, the Coordinator service is able to derive addresses and watch


### PR DESCRIPTION
Use more portable markdown syntax for image references, so images are rendered correctly for both markdown and mkdocs.

Fix mkdocs formatting issues for regression test howto document.