### PR TITLE
Start sshd by default for dev-flavored ISO

### DIFF
--- a/live-usb-creator/README.md
+++ b/live-usb-creator/README.md
@@ -135,7 +135,10 @@ VM related stuff:
     building a release image that will work out of the box. Specifically,
 
       * `data_app_subzero/` should contain `subzero-cli.jar`,
-      `subzero-signed.sar`, `subzero-userdata-signed`.
+      `subzero-signed.sar`, `subzero-userdata-signed.sar`, where
+      `subzero-cli.jar` is `gui-1.0.0-SNAPSHOT-shaded.jar` renamed, and the latter
+      two `.sar` files are the signed artifacts of `make prod` on a properly
+      configured machine with an HSM.
       * `/dev/sda1` when mounted to `/hd`, should have the HSM and wallets
       files contained in `/hd/local` and `/hd/wallets`, respectively.
 

--- a/live-usb-creator/data_app_subzero/sshd_config
+++ b/live-usb-creator/data_app_subzero/sshd_config
@@ -1,0 +1,139 @@
+#	$OpenBSD: sshd_config,v 1.100 2016/08/15 12:32:04 naddy Exp $
+
+# This is the sshd server system-wide configuration file.  See
+# sshd_config(5) for more information.
+
+# This sshd was compiled with PATH=/usr/local/bin:/usr/bin
+
+# The strategy used for options in the default sshd_config shipped with
+# OpenSSH is to specify options with their default value where
+# possible, but leave them commented.  Uncommented options override the
+# default value.
+
+# If you want to change the port on a SELinux system, you have to tell
+# SELinux about this change.
+# semanage port -a -t ssh_port_t -p tcp #PORTNUMBER
+#
+#Port 22
+#AddressFamily any
+#ListenAddress 0.0.0.0
+#ListenAddress ::
+
+HostKey /etc/ssh/ssh_host_rsa_key
+#HostKey /etc/ssh/ssh_host_dsa_key
+HostKey /etc/ssh/ssh_host_ecdsa_key
+HostKey /etc/ssh/ssh_host_ed25519_key
+
+# Ciphers and keying
+#RekeyLimit default none
+
+# Logging
+#SyslogFacility AUTH
+SyslogFacility AUTHPRIV
+#LogLevel INFO
+
+# Authentication:
+
+#LoginGraceTime 2m
+PermitRootLogin yes
+#StrictModes yes
+#MaxAuthTries 6
+#MaxSessions 10
+
+#PubkeyAuthentication yes
+
+# The default is to check both .ssh/authorized_keys and .ssh/authorized_keys2
+# but this is overridden so installations will only check .ssh/authorized_keys
+AuthorizedKeysFile	.ssh/authorized_keys
+
+#AuthorizedPrincipalsFile none
+
+#AuthorizedKeysCommand none
+#AuthorizedKeysCommandUser nobody
+
+# For this to work you will also need host keys in /etc/ssh/ssh_known_hosts
+#HostbasedAuthentication no
+# Change to yes if you don't trust ~/.ssh/known_hosts for
+# HostbasedAuthentication
+#IgnoreUserKnownHosts no
+# Don't read the user's ~/.rhosts and ~/.shosts files
+#IgnoreRhosts yes
+
+# To disable tunneled clear text passwords, change to no here!
+#PasswordAuthentication yes
+PermitEmptyPasswords yes
+PasswordAuthentication yes
+
+# Change to no to disable s/key passwords
+#ChallengeResponseAuthentication yes
+ChallengeResponseAuthentication no
+
+# Kerberos options
+#KerberosAuthentication no
+#KerberosOrLocalPasswd yes
+#KerberosTicketCleanup yes
+#KerberosGetAFSToken no
+#KerberosUseKuserok yes
+
+# GSSAPI options
+GSSAPIAuthentication yes
+GSSAPICleanupCredentials no
+#GSSAPIStrictAcceptorCheck yes
+#GSSAPIKeyExchange no
+#GSSAPIEnablek5users no
+
+# Set this to 'yes' to enable PAM authentication, account processing,
+# and session processing. If this is enabled, PAM authentication will
+# be allowed through the ChallengeResponseAuthentication and
+# PasswordAuthentication.  Depending on your PAM configuration,
+# PAM authentication via ChallengeResponseAuthentication may bypass
+# the setting of "PermitRootLogin without-password".
+# If you just want the PAM account and session checks to run without
+# PAM authentication, then enable this but set PasswordAuthentication
+# and ChallengeResponseAuthentication to 'no'.
+# WARNING: 'UsePAM no' is not supported in Red Hat Enterprise Linux and may cause several
+# problems.
+UsePAM yes
+
+#AllowAgentForwarding yes
+#AllowTcpForwarding yes
+#GatewayPorts no
+X11Forwarding yes
+#X11DisplayOffset 10
+#X11UseLocalhost yes
+#PermitTTY yes
+#PrintMotd yes
+#PrintLastLog yes
+#TCPKeepAlive yes
+#UseLogin no
+#UsePrivilegeSeparation sandbox
+#PermitUserEnvironment no
+#Compression delayed
+#ClientAliveInterval 0
+#ClientAliveCountMax 3
+#ShowPatchLevel no
+#UseDNS yes
+#PidFile /var/run/sshd.pid
+#MaxStartups 10:30:100
+#PermitTunnel no
+#ChrootDirectory none
+#VersionAddendum none
+
+# no default banner path
+#Banner none
+
+# Accept locale-related environment variables
+AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES
+AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT
+AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE
+AcceptEnv XMODIFIERS
+
+# override default of no subsystems
+Subsystem	sftp	/usr/libexec/openssh/sftp-server
+
+# Example of overriding settings on a per-user basis
+#Match User anoncvs
+#	X11Forwarding no
+#	AllowTcpForwarding no
+#	PermitTTY no
+#	ForceCommand cvs server

--- a/live-usb-creator/live_scripts/startup
+++ b/live-usb-creator/live_scripts/startup
@@ -3,11 +3,14 @@
 # /etc/rc.d/init.d/livesys calls out to this script (/usr/local/bin/startup), meaning it’s run on startup.
 # Note that it does NOT block a TTY/login/bash/etc., hence the nfast_block_shell utility script.
 
-# Install protobuf only for dev ISO
+# Install protobuf and enable sshd, only for dev ISO
 if [ -f "/usr/local/bin/.isotype_dev" ]; then
   /usr/local/bin/install_protobuf
   ln -Tsf /bin/python3 /bin/python
   /usr/local/bin/install_nfast_tools_dev
+  cp /data/app/subzero/sshd_config /etc/ssh/sshd_config
+  rm /data/app/subzero/sshd_config
+  service sshd start
 else
   /usr/local/bin/install_nfast_tools_release
 fi


### PR DESCRIPTION
This change is to facilitate development. Note you may still want to run the a dev flavored ISO in a segregated network to reduce the attack surface to the development box.

This change also makes it possible/easier to build the codesafe target in CI/CD using the dev-flavored ISO.

We also improve live-usb-creator documentation.