### PR TITLE
Replace file globbing approach with explicit file list for cmake

### DIFF
--- a/core/proto/CMakeLists.txt
+++ b/core/proto/CMakeLists.txt
@@ -2,7 +2,10 @@ set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../nanopb/extra/)
 find_package(Nanopb REQUIRED)
 include_directories(${NANOPB_INCLUDE_DIRS})
 
-file(GLOB protos "squareup/subzero/*.proto")
+set(protos
+    "${CMAKE_CURRENT_LIST_DIR}/squareup/subzero/internal.proto"
+    "${CMAKE_CURRENT_LIST_DIR}/squareup/subzero/common.proto"
+)
 
 nanopb_generate_cpp(PROTO_SRCS PROTO_HDRS ${protos} RELPATH ${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
This change makes it less difficult to produce deterministic builds, in particular, in the live ISO and in a docker container built on top of the the ISO. The problem with file globbing is that the order of globbed files is dependent on the underlying filesystem. We discovered this descrepency while building the same verson of subzero core with the same toolchain version in an identical build path, in a system booted from an live ISO (with an ext4 filesystem), and in a docker container (with an overlay filesystem) created from the same live ISO, which resulted in differed subzero binaries.