### PR TITLE
Bump com.google.guava:guava to 30.0-jre

### DIFF
--- a/java/shared/pom.xml
+++ b/java/shared/pom.xml
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>29.0-jre</version>
+      <version>30.0-jre</version>
     </dependency>
     <dependency>
       <groupId>com.google.zxing</groupId>


### PR DESCRIPTION
Resolve a dependabot alert for CVE-2020-8908.