### PR TITLE
Binary static analysis for subzero CORE

### DIFF
--- a/.github/workflows/binary-static-analysis.yml
+++ b/.github/workflows/binary-static-analysis.yml
@@ -1,0 +1,70 @@
+# Binary static analysis of subzero CORE, to make sure it's built properly
+name: "Binary Static Analysis"
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [master]
+  schedule:
+    # Daily at 2:42am
+    - cron: '42 3 * * *'
+
+jobs:
+  bincheck:
+    name: "Binary Static Analysis"
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -euxo pipefail {0}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.9]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with:
+        # We must fetch at least the immediate parents so that if this is
+        # a pull request then we can checkout the head.
+        fetch-depth: 2
+        submodules: 'recursive'
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Display Python version
+      run: |
+        python -c "import sys; print(sys.version)"
+
+    - name: Install build dependencies
+      run: |
+        scripts/ubuntu_install_protobuf.sh
+
+    - name: Build subzero CORE
+      run: |
+        scripts/build_core.sh
+
+    # Run binary static analysis
+    - name: Run binary static analysis
+      run: |
+        dev_testnet_expected=$(echo -e "GATEWAY TYPE: TESTNET\nAES KEY TYPE: DEV" \
+          | sha256sum | cut -f1 -d' ')
+        dev_mainnet_expected=$(echo -e "GATEWAY TYPE: MAINNET\nAES KEY TYPE: DEV" \
+          | sha256sum | cut -f1 -d' ')
+        dev_testnet=$(scripts/binary_static_analysis.sh core/build/subzero_testnet \
+          2> /dev/null | sha256sum | cut -f1 -d' ')
+        dev_mainnet=$(scripts/binary_static_analysis.sh core/build/subzero_mainnet \
+          2> /dev/null | sha256sum | cut -f1 -d' ')
+        if [[ $dev_testnet_expected != $dev_testnet ]]; then
+          exit 1
+        fi
+        if [[ $dev_mainnet_expected != $dev_mainnet ]]; then
+          exit 2
+        fi
+

--- a/.github/workflows/binary-static-analysis.yml
+++ b/.github/workflows/binary-static-analysis.yml
@@ -53,18 +53,4 @@ jobs:
     # Run binary static analysis
     - name: Run binary static analysis
       run: |
-        dev_testnet_expected=$(echo -e "GATEWAY TYPE: TESTNET\nAES KEY TYPE: DEV" \
-          | sha256sum | cut -f1 -d' ')
-        dev_mainnet_expected=$(echo -e "GATEWAY TYPE: MAINNET\nAES KEY TYPE: DEV" \
-          | sha256sum | cut -f1 -d' ')
-        dev_testnet=$(scripts/binary_static_analysis.sh core/build/subzero_testnet \
-          2> /dev/null | sha256sum | cut -f1 -d' ')
-        dev_mainnet=$(scripts/binary_static_analysis.sh core/build/subzero_mainnet \
-          2> /dev/null | sha256sum | cut -f1 -d' ')
-        if [[ $dev_testnet_expected != $dev_testnet ]]; then
-          exit 1
-        fi
-        if [[ $dev_mainnet_expected != $dev_mainnet ]]; then
-          exit 2
-        fi
-
+        scripts/bsa_check_core.sh core/build

--- a/.github/workflows/signtx-test.yml
+++ b/.github/workflows/signtx-test.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Run Subzero CORE
       run: |
         cd ${{ github.workspace }}
-        ./core/build/subzero &
+        ./core/build/subzero_testnet &
 
     - name: Run SignTx Test
       run: |

--- a/.github/workflows/signtx-test.yml
+++ b/.github/workflows/signtx-test.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Run Subzero CORE
       run: |
         cd ${{ github.workspace }}
-        ./core/build/subzero_testnet &
+        ./core/build/subzero-testnet &
 
     - name: Run SignTx Test
       run: |

--- a/core/include/aes_gcm_dev.h
+++ b/core/include/aes_gcm_dev.h
@@ -3,6 +3,10 @@
 /* This header is meant for the dev target, and should only be included in the
  * dev implementation */
 
+// magic string for binary static analysis
+// aes_gcm_dev:$(echo -n "aes_gcm_dev" | sha256sum | cut -c1-16)
+#define MAGIC "aes_gcm_dev:8873b8689d31cc4d"
+
 // M_KeyID typedef for the dev target
 //
 // Note that it's a re-definition of the codesafe-specific M_KeyID type. M_keyID

--- a/core/include/aes_gcm_ncipher.h
+++ b/core/include/aes_gcm_ncipher.h
@@ -3,6 +3,10 @@
 /* This header is meant for the nCipher target, and should only be included in the
  * codesafe/ncipher implementation */
 
+// magic string for binary static analysis
+// aes_gcm_ncipher:$(echo -n "aes_gcm_ncipher" | sha256sum | cut -c1-16)
+#define MAGIC "aes_gcm_ncipher:ffb944993c73a1d3"
+
 Result aes_gcm_encrypt(M_KeyID keyId, uint8_t *plaintext, size_t plaintext_len,
                        uint8_t *ciphertext, size_t ciphertext_len,
                        size_t *bytes_written);

--- a/core/src/protect.c
+++ b/core/src/protect.c
@@ -5,6 +5,10 @@
  */
 Result protect_pubkey(char xpub[static XPUB_SIZE],
                       EncryptedPubKey *encrypted_pub_key) {
+  // Insert magic string for binary static analysis.
+  // This is extremely hacky, but works. ¯\_(ツ)_/¯
+  printf(MAGIC);
+
   static_assert(sizeof(encrypted_pub_key->encrypted_pub_key.bytes) >=
                 XPUB_SIZE + 12 + 16,
                 "misconfigured encrypted_pub_key max size");

--- a/scripts/binary_static_analysis.sh
+++ b/scripts/binary_static_analysis.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+
+# This is a simple static analysis tool for subzero core. It checks 
+# - which gateway address is present in the subzero binary. Gateway address
+# types are: "TESTNET", "MAINNET", "UNKNOWN"
+# - which AES-GCM key type is present in the subzero binary. Key types are:
+# "DEV", "NCIPHER", "UNKNOWN"
+
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 /path/to/subzero_binary"
+    exit 1
+fi
+
+#########################################
+# SHA256 digests of gateway addresses
+#########################################
+# TESTNET gateway
+# echo -n "tpubDA3zCqbkh8BS1h3VGmB6VU1Cj638VJufBcDWSeZVw3aEE9rzvmrNoKyGFqDwr8d9rhf4sh4Yjg8LVwkehVF3Aoyss1KdDFLoiarFJQvqp4R" | sha256sum
+# Gateway address is from core/include/config.h
+GATEWAY_TESTNET_SHA256SUM="f772a01ae01fd49179e3d8c18d7cc95374bb5055323ef9b08fc1dd8dabd6e05f"
+
+# MAINNET gateway
+# echo -n "xpub68ititM5jRbzS14gpMD18Mo2VUqwwgfTu3EK2PjXTKeM69LSJvhrhGcbguicH313zwvZaoYtUwjU8vKoskUmsPJMjQ8oeZzVRmcBixXKELV" | sha256sum
+# Gatewy address is from core/include/config.h
+GATEWAY_MAINNET_SHA256SUM="2441ac96a8102ae06412f3c7082077f29332efc17e121f314442c3e279ea6d07"
+
+# SHA256 digest of empty string, for debugging reference
+# EMPYT_STRING_SHA256SUM="e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+#########################################
+# AES key type magic strings
+#########################################
+# Shall be in sync with MAGIC value in core/include/aes_gcm_dev.h
+MAGIC_DEV="aes_gcm_dev:8873b8689d31cc4d"
+# Shall be in sync with MAGIC value in core/include/aes_gcm_ncipher.h
+MAGIC_NCIPHER="aes_gcm_ncipher:ffb944993c73a1d3"
+
+# return sha256sum of string that matches pattern in subzero_bin
+function find_gateway_digest {
+    pattern="$1"
+    subzero_bin="$2"
+    ret=$(strings "$subzero_bin" | \
+          grep -Eo "${pattern}[[:alnum:]]*" | \
+          tr -d '\n' | \
+          sha256sum | \
+          cut -f1 -d ' ')
+    echo "$ret"
+}
+
+# print "TESTNET", "MAINNET", or "UNKNOWN" as gateway type
+function print_gateway_address_type {
+    subzero_bin="$1"
+
+    # Check for testnet gateway
+    if [ "$GATEWAY_TESTNET_SHA256SUM" \
+          = $(find_gateway_digest "tpubDA3z" "$subzero_bin") ]; then
+      testnet=1
+    else
+      testnet=0
+    fi
+
+    # Check for mainnet gateway
+    if [ "$GATEWAY_MAINNET_SHA256SUM" \
+          = $(find_gateway_digest "xpub68it" "$subzero_bin") ]; then
+      mainnet=1
+    else
+      mainnet=0
+    fi
+
+    count=$(( $testnet + $mainnet ))
+    if [ $count != 1 ]; then
+      echo "GATEWAY TYPE: UNKNOWN"
+      if [ $count == 0 ]; then
+        >&2 echo "No gateway address detected"
+      else
+        >&2 echo "More than one gateway address detected"
+      fi
+      return 0
+    fi
+
+    if [ "x$testnet" == "x1" ]; then
+      echo "GATEWAY TYPE: TESTNET"
+      return 0
+    fi
+
+    if [ "x$mainnet" == "x1" ]; then
+      echo "GATEWAY TYPE: MAINNET"
+      return 0
+    fi
+
+   # Should never get here
+   exit 1
+}
+
+
+# print "DEV" or "NCIPHER" as AES key type
+function print_aes_key_type {
+  subzero_bin="$1"
+
+  if grep -q "$MAGIC_DEV" $subzero_bin; then
+    echo "AES KEY TYPE: DEV"
+  elif grep -q "$MAGIC_NCIPHER" $subzero_bin; then
+    echo "AES KEY TYPE: NCIPHER"
+  else
+    echo "AES KEY TYPE: UNKNOWN"
+  fi
+
+  return 0
+}
+
+print_gateway_address_type "$1"
+print_aes_key_type "$1"

--- a/scripts/binary_static_analysis.sh
+++ b/scripts/binary_static_analysis.sh
@@ -1,10 +1,18 @@
 #!/usr/bin/env bash
 
 # This is a simple static analysis tool for subzero core. It checks 
-# - which gateway address is present in the subzero binary. Gateway address
-# types are: "TESTNET", "MAINNET", "UNKNOWN"
-# - which AES-GCM key type is present in the subzero binary. Key types are:
-# "DEV", "NCIPHER", "UNKNOWN"
+# - which gateway address type is present in the subzero binary.
+#   Function `print_gateway_address_type` prints one of the following values
+#   to STDOUT
+#   * "GATEWAY TYPE: TESTNET"
+#   * "GATEWAY TYPE: MAINNET"
+#   * "GATEWAY TYPE: UNKNOWN"
+# - which AES-GCM key type is present in the subzero binary.
+#   Function `print_aes_key_type` prints one of the following values to
+#   STDIN
+#   * "AES KEY TYPE: DEV"
+#   * "AES KEY TYPE: NCIPHER"
+#   * "AES KEY TYPE: UNKNOWN"
 
 set -euo pipefail
 

--- a/scripts/bsa_check_core.sh
+++ b/scripts/bsa_check_core.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 /path/to/check_dir"
+    exit 1
+fi
+
+CHECK_DIR="$1"
+SCRIPT_ROOT=$(cd "$(dirname "$0")"; pwd -P)
+EXPECTED_OUTPUT_DEV_TESTNET="GATEWAY TYPE: TESTNET\nAES KEY TYPE: DEV"
+EXPECTED_OUTPUT_DEV_MAINNET="GATEWAY TYPE: MAINNET\nAES KEY TYPE: DEV"
+
+function check_output {
+  subzero_bin="$1"
+  expected_output="$2"
+
+  output_digest=$(${SCRIPT_ROOT}/binary_static_analysis.sh ${subzero_bin} \
+    | sha256sum | cut -f1 -d' ')
+  expected_output_digest=$(echo -e "${expected_output}" \
+    | sha256sum | cut -f1 -d' ')
+
+  if [[ $output_digest != $expected_output_digest ]]; then
+          echo "Binary static analysis failed on ${subzero_bin}"
+          exit 1
+  fi
+}
+
+# Run binary static analysis on dev-testnet and dev-mainnet targets
+check_output "${CHECK_DIR}/subzero-testnet" "$EXPECTED_OUTPUT_DEV_TESTNET"
+check_output "${CHECK_DIR}/subzero-mainnet" "$EXPECTED_OUTPUT_DEV_MAINNET"

--- a/scripts/build_core.sh
+++ b/scripts/build_core.sh
@@ -5,12 +5,12 @@ set -euxo pipefail
 cd "$(dirname $0)"/..
 mkdir -p core/build
 cd core/build
-# For testnet. Generate compile_db for clang static analyzer
-TARGET=dev CURRENCY=btc-testnet cmake ../ -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
-make
-mv subzero subzero_testnet
 # For mainnet. Skip compile_db generation
-make clean
 TARGET=dev CURRENCY=btc-mainnet cmake ../
 make
 mv subzero subzero_mainnet
+# For testnet. Generate compile_db for clang static analyzer
+make clean
+TARGET=dev CURRENCY=btc-testnet cmake ../ -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+make
+mv subzero subzero_testnet

--- a/scripts/build_core.sh
+++ b/scripts/build_core.sh
@@ -8,9 +8,9 @@ cd core/build
 # For mainnet. Skip compile_db generation
 TARGET=dev CURRENCY=btc-mainnet cmake ../
 make
-mv subzero subzero_mainnet
+mv subzero subzero-mainnet
 # For testnet. Generate compile_db for clang static analyzer
 make clean
 TARGET=dev CURRENCY=btc-testnet cmake ../ -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 make
-mv subzero subzero_testnet
+mv subzero subzero-testnet

--- a/scripts/build_core.sh
+++ b/scripts/build_core.sh
@@ -5,5 +5,12 @@ set -euxo pipefail
 cd "$(dirname $0)"/..
 mkdir -p core/build
 cd core/build
+# For testnet. Generate compile_db for clang static analyzer
 TARGET=dev CURRENCY=btc-testnet cmake ../ -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 make
+mv subzero subzero_testnet
+# For mainnet. Skip compile_db generation
+make clean
+TARGET=dev CURRENCY=btc-mainnet cmake ../
+make
+mv subzero subzero_mainnet


### PR DESCRIPTION
Add a simple binary static analysis tool to help catch potential misconfigurations in building the core.
The tool checks the built subzero core binary for its currency type and AES key type.
The check is added in GHA CI.