### PR TITLE
Add a UI option to graceful_shutdown

### DIFF
--- a/java/gui/src/main/java/com/squareup/subzero/SubzeroGui.java
+++ b/java/gui/src/main/java/com/squareup/subzero/SubzeroGui.java
@@ -144,8 +144,11 @@ public class SubzeroGui {
 
         String encoded = base64().encode(response.toByteArray());
 
-        Screens.ExitOrRestart command = screens.displayQRCode(encoded);
-        if (command == Screens.ExitOrRestart.Exit) {
+        Screens.ExitOrRestartOrPowerOff command = screens.displayQRCode(encoded);
+        if (command == Screens.ExitOrRestartOrPowerOff.Exit) {
+          return;
+        } else if (command == Screens.ExitOrRestartOrPowerOff.PowerOff){
+          SystemShutdown.systemShutdown();
           return;
         }
       }
@@ -191,8 +194,8 @@ public class SubzeroGui {
         String big = new String(new char[1999]).replace("\0", "M");
         screens.displayQRCode(big); // return value ignored so exit doesn't work
         // reflect back the original scanned QR code:
-        Screens.ExitOrRestart command = screens.displayQRCode(input);
-        if (command == Screens.ExitOrRestart.Exit) {
+        Screens.ExitOrRestartOrPowerOff command = screens.displayQRCode(input);
+        if (command == Screens.ExitOrRestartOrPowerOff.Exit) {
           return;
         }
         // otherwise command was restart, and we loop.

--- a/java/gui/src/main/java/com/squareup/subzero/SystemShutdown.java
+++ b/java/gui/src/main/java/com/squareup/subzero/SystemShutdown.java
@@ -1,0 +1,17 @@
+package com.squareup.subzero;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+
+public class SystemShutdown {
+    /**
+     * Initiate a graceful shutdown of the machine(Linux only, NOP for others(Mac)).
+     */
+    public static void systemShutdown() throws Exception{
+
+        if (System.getProperty("os.name").contains("Linux")) {
+            Runtime.getRuntime().exec("shutdown now");
+        }
+        return;
+    }
+}

--- a/java/gui/src/main/java/com/squareup/subzero/framebuffer/Screens.java
+++ b/java/gui/src/main/java/com/squareup/subzero/framebuffer/Screens.java
@@ -213,7 +213,7 @@ public class Screens {
     System.out.println("Displaying QR code. Data: " + encodedData);
 
     String message = "We are done. Please scan the following QR-code with the blue scanner.\n"
-            + "Then type 'exit' + <enter> or 'restart' + <enter>."
+            + "Then type 'exit' + <enter> or 'restart' + <enter>.\n"
             + "To turn off the machine type 'poweroff' + <enter>.";
 
     framebuffer.draw((Graphics2D g) -> {
@@ -249,7 +249,7 @@ public class Screens {
     });
 
     int offset = framebuffer.getHeight() - 60;
-    framebuffer.text("Type 'exit' or 'restart'", 18, offset);
+    framebuffer.text("Type 'exit' or 'restart' or 'poweroff'", 18, offset);
     while (true) {
       String command = framebuffer.prompt(18, offset + 20, false);
       if (command.equalsIgnoreCase("restart")) {
@@ -259,7 +259,7 @@ public class Screens {
       } else if (command.equalsIgnoreCase("poweroff")){
         return ExitOrRestartOrPowerOff.PowerOff;
       }
-      framebuffer.text("That wasn't 'exit' or 'restart'. Try again.", 18, offset);
+      framebuffer.text("That wasn't 'exit' or 'restart' or 'poweroff'. Try again.", 18, offset);
     }
   }
 

--- a/java/gui/src/main/java/com/squareup/subzero/framebuffer/Screens.java
+++ b/java/gui/src/main/java/com/squareup/subzero/framebuffer/Screens.java
@@ -195,9 +195,10 @@ public class Screens {
     return promptPassword("Please confirm the password");
   }
 
-  public enum ExitOrRestart {
+  public enum ExitOrRestartOrPowerOff {
     Exit,
     Restart,
+    PowerOff,
   }
 
   /**
@@ -207,12 +208,13 @@ public class Screens {
    * @throws IOException
    * @throws WriterException
    */
-  public ExitOrRestart displayQRCode(String encodedData) throws IOException {
+  public ExitOrRestartOrPowerOff displayQRCode(String encodedData) throws IOException {
 
     System.out.println("Displaying QR code. Data: " + encodedData);
 
-    String message = "We are done. Please scan the following QR-code with the blue scanner.\n" +
-        "Then type 'exit' + <enter> or 'restart' + <enter>.";
+    String message = "We are done. Please scan the following QR-code with the blue scanner.\n"
+            + "Then type 'exit' + <enter> or 'restart' + <enter>."
+            + "To turn off the machine type 'poweroff' + <enter>.";
 
     framebuffer.draw((Graphics2D g) -> {
       baseScreenLayout(g, "QR Code Output", message, Color.white);
@@ -251,9 +253,11 @@ public class Screens {
     while (true) {
       String command = framebuffer.prompt(18, offset + 20, false);
       if (command.equalsIgnoreCase("restart")) {
-        return ExitOrRestart.Restart;
+        return ExitOrRestartOrPowerOff.Restart;
       } else if (command.equalsIgnoreCase("exit")) {
-        return ExitOrRestart.Exit;
+        return ExitOrRestartOrPowerOff.Exit;
+      } else if (command.equalsIgnoreCase("poweroff")){
+        return ExitOrRestartOrPowerOff.PowerOff;
       }
       framebuffer.text("That wasn't 'exit' or 'restart'. Try again.", 18, offset);
     }

--- a/java/gui/src/test/java/com/squareup/subzero/SystemShutdownTest.java
+++ b/java/gui/src/test/java/com/squareup/subzero/SystemShutdownTest.java
@@ -1,0 +1,30 @@
+package com.squareup.subzero;
+import org.junit.Test;
+import static org.assertj.core.api.Java6Assertions.assertThat;
+
+public class SystemShutdownTest {
+    @Test
+    public void testSystemShutdown(){
+        if (System.getProperty("os.name").contains("Linux")) {
+            try {
+                SystemShutdown.systemShutdown();
+                assertThat(false);
+            } catch (Exception e) {
+                //should throw exception as shutdown now as non root user on Linux should fail.
+                assertThat(true);
+
+            }
+
+        } else {
+            try {
+                //NOP
+                SystemShutdown.systemShutdown();
+                assertThat(true);
+            } catch (Exception e){
+                //should not throw an exception.
+                assertThat(false);
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
When the operator is done using the HSM, they should have
an option to gracefully shutdown the machine.
That should prevent:
1. File system corruption.
2. May aid in longevity of the HSM itself.

This PR adds an option to the prompt and executed the linux shutdown
command on the back.