### PR TITLE
Enable Allstar at repository level

### DIFF
--- a/.allstar/allstar.yaml
+++ b/.allstar/allstar.yaml
@@ -1,0 +1,2 @@
+optConfig:
+  optIn: true

--- a/.allstar/binary_artifacts.yaml
+++ b/.allstar/binary_artifacts.yaml
@@ -1,0 +1,3 @@
+optConfig:
+  optIn: true
+action: issue

--- a/.allstar/branch_protection.yaml
+++ b/.allstar/branch_protection.yaml
@@ -1,0 +1,9 @@
+optConfig:
+  optIn: true
+action: issue
+enforceDefault: true
+enforceBranches: [ master ]
+requireApproval: true
+approvalCount: 1
+dismissStale: true
+blockForce: true

--- a/.allstar/outside.yaml
+++ b/.allstar/outside.yaml
@@ -1,0 +1,3 @@
+optConfig:
+  optIn: true
+action: issue

--- a/.allstar/security.yaml
+++ b/.allstar/security.yaml
@@ -1,0 +1,3 @@
+optConfig:
+  optIn: true
+action: issue

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,3 @@
+# Reporting Security Issues
+
+See [BUG-BOUNTY.md](./BUG-BOUNTY.md).


### PR DESCRIPTION
Enable Allstar for subzero to set and check security policies.
See https://github.com/ossf/allstar/blob/main/README.md for detail.

The first commit in this pull request enables Allstar and configures the security policy.
The second commit in this pull request adds file `SECURITY.md`, which is to make the repository setting compliant with Allstar policy.