### PR TITLE
strict checking on TARGET

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -8,11 +8,16 @@ string(LENGTH "${CMAKE_SOURCE_DIR}/" SOURCE_PATH_SIZE)
 add_definitions("-DSOURCE_PATH_SIZE=${SOURCE_PATH_SIZE}")
 
 if ($ENV{TARGET} MATCHES "nCipher")
+  message("Building for nCipher(powerpc32) architecture.")
   include(codesafe.cmake)
 
   if ($ENV{UNSIGNED} MATCHES "yes")
-     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DUNSIGNED")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DUNSIGNED")
   endif ()
+elseif($ENV{TARGET} MATCHES "dev")
+  message("Building for the host architecture")
+else()
+  message(FATAL_ERROR "Unsupported TARGET value.")
 endif ()
 
 add_subdirectory(trezor-crypto)


### PR DESCRIPTION
don't allow the cmake setup to silently accept typo TARGET values.

At the moment only 2 values are supported:
1. nCipher - build for the ncipher SoloXC(powerpc32)
2. dev - build for the host architecture(x86_64).

In future we might add support for:
1. Apple M1.
2. wasm.