### PR TITLE
bits2qr_fb.py: convert file to QR code, then output to framebuffer

### DIFF
--- a/live-usb-creator/.gitignore
+++ b/live-usb-creator/.gitignore
@@ -6,3 +6,4 @@ kernel-devel-3.10.0-957.12.2.el7.x86_64.rpm
 protoc-3.14.0-linux-x86_64.zip
 six-1.15.0-py2.py3-none-any.whl
 protobuf-3.14.0-cp36-cp36m-manylinux1_x86_64.whl
+Pillow-8.3.2-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl

--- a/live-usb-creator/README.md
+++ b/live-usb-creator/README.md
@@ -16,13 +16,15 @@ Set the following files in place in the same directory as the `Vagrantfile`.
 * protoc-3.14.0-linux-x86_64.zip (1.6MB): `curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v3.14.0/protoc-3.14.0-linux-x86_64.zip`
 * six-1.15.0-py2.py3-none-any.whl (11.0kB): `curl -L -O https://files.pythonhosted.org/packages/ee/ff/48bde5c0f013094d729fe4b0316ba2a24774b3ff1c52d924a8a4cb04078a/six-1.15.0-py2.py3-none-any.whl`
 * protobuf-3.14.0-cp36-cp36m-manylinux1_x86_64.whl (1MB): `curl -O -L https://files.pythonhosted.org/packages/fe/fd/247ef25f5ec5f9acecfbc98ca3c6aaf66716cf52509aca9a93583d410493/protobuf-3.14.0-cp36-cp36m-manylinux1_x86_64.whl`
+* Pillow-8.3.2-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl (3.0 MB): `curl -O -L  https://files.pythonhosted.org/packages/6f/2b/7c242e58b1b332a123b4a7bf358e2cc7fa7d904b3576b87defc9528e2bfd/Pillow-8.3.2-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl`
 
 Verify the following SHA256 sums:
 
 ```bash
 $ shasum -a 256 CodeSafe-linux64-dev-12.50.2.iso Codesafe_Lin64-12.63.0.iso CentOS-7-x86_64-Everything-1908.iso \
 kernel-devel-3.10.0-957.12.2.el7.x86_64.rpm protoc-3.14.0-linux-x86_64.zip \
-six-1.15.0-py2.py3-none-any.whl protobuf-3.14.0-cp36-cp36m-manylinux1_x86_64.whl
+six-1.15.0-py2.py3-none-any.whl protobuf-3.14.0-cp36-cp36m-manylinux1_x86_64.whl \
+Pillow-8.3.2-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl
 23ca2c5fc2476887926409bc69f19b772c99191b1e0cce1a3bace8d1e4488528  CodeSafe-linux64-dev-12.50.2.iso
 df928054888f466c263ef1d7de37877bdcf27c632b34c6934b6eee4e8697a6de  Codesafe_Lin64-12.63.0.iso
 bd5e6ca18386e8a8e0b5a9e906297b5610095e375e4d02342f07f32022b13acf  CentOS-7-x86_64-Everything-1908.iso
@@ -30,6 +32,7 @@ a27c718efb2acec969b20023ea517d06317b838714cb359e4a80e8995ac289fc  kernel-devel-3
 a2900100ef9cda17d9c0bbf6a3c3592e809f9842f2d9f0d50e3fba7f3fc864f0  protoc-3.14.0-linux-x86_64.zip
 8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced  six-1.15.0-py2.py3-none-any.whl
 ecc33531a213eee22ad60e0e2aaea6c8ba0021f0cce35dbf0ab03dee6e2a23a1  protobuf-3.14.0-cp36-cp36m-manylinux1_x86_64.whl
+8f284dc1695caf71a74f24993b7c7473d77bc760be45f776a2c2f4e04c170550  Pillow-8.3.2-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl
 ```
 
 The CentOS's GPG signature can also be verified to confirm the image has been signed by the CentOS team.
@@ -116,7 +119,10 @@ VM related stuff:
 
 * `Vagrantfile`: Provisions a VirtualBox VM in which the live system ISO will be built using the Vagrant tool.
 * `bootstrap.sh`: A shell script that runs at the very end of VM bringup. (Currently just mounts the CodeSafe ISO.)
-* `build.sh`: Manually run by the user to kick off the ISO build. Currently includes some patches for Lorax and Kickstart files applied before running the build proper with `livemedia-creator`. Two image types, development and release, can be built.
+* `build.sh`: Manually run by the user to kick off the ISO build.
+Currently includes some patches for Lorax and Kickstart files applied
+before running the build proper with `livemedia-creator`. Two image
+ypes, development and release, can be built.
   * Release build: `build.sh` or `build.sh release`.
 
     A release image is to be used by cold storage operators who do not need
@@ -160,8 +166,17 @@ VM related stuff:
 
 Install related stuff:
 
-* `rhel7-livemedia.ks`: This is the “kickstart” file that scripts the CentOS install by anaconda. Modified from the version that exists on the VM guest under the path `/usr/share/doc/lorax-*/rhel7-livemedia.ks`. I’ve tried to factor out most of the interesting stuff so you don’t have to touch this gross file. See my changes versus the CentOS/Fedora example liveiso kickstart by running `diff rhel7-livemedia.ks.orig rhel7-livemedia.ks`. Mostly I removed the GNOME desktop/X11, added couple packages
-to %packages, and added in hooks for the below.
+* `rhel7-livemedia.ks`: This is the “kickstart” file that scripts the
+CentOS install by anaconda, for the `release` image. Modified from the
+version that exists on the VM guest under the path
+`/usr/share/doc/lorax-*/rhel7-livemedia.ks`. I’ve tried to factor out
+most of the interesting stuff so you don’t have to touch this gross
+file. See my changes versus the CentOS/Fedora example liveiso
+kickstart by running `diff rhel7-livemedia.ks.orig
+rhel7-livemedia.ks`. Mostly I removed the GNOME desktop/X11, added
+couple packages to %packages, and added in hooks for the below.
+* `rhel7-livemedia-dev.ks`: This is the anaconda kickstart file used to
+build the `dev` (development) image.
 * `install_scripts/0_post_install_nochroot`: This bash script is executed by anaconda (the CentOS installer) directly after install (but before `install_scripts/1_post_install_chroot`). From the point of view of the script, the newly installed CentOS (soon to be implanted in our live ISO) lives at `/mnt/sysimage/opt/`, and this directory (the one containing the `Vagrantfile`) lives at `/vagrant/`. That makes this bash script the ideal place to copy files onto the root filesystem of the newly installed CentOS.
 * `install_scripts/1_post_install_chroot`: This bash script is executed by anaconda (the CentOS installer) directly after install (but after `install_scripts/0_post_install_nochroot`). From the point of view of the script, the newly installed CentOS (soon to be implanted in our live ISO) is chrooted to `/`. That makes this bash script the ideal place to run Linux binaries (like useradd, systemctl, yum-config-manager, etc.) that change system state.
 

--- a/live-usb-creator/data_app_subzero/tools/bits2qr_fb.py
+++ b/live-usb-creator/data_app_subzero/tools/bits2qr_fb.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+
+"""Some simplistic assumptions to make life easy.
+
+bits_per_pixel    memory layout
+16                rgb565
+24                rgb
+32                argb
+"""
+
+import os
+from PIL import Image
+import argparse
+import tempfile
+import subprocess
+import shlex
+
+def _read_and_convert_to_ints(filename):
+  with open(filename, "r") as fp:
+    content = fp.read()
+    tokens = content.strip().split(",")
+    return [int(t) for t in tokens if t]
+
+
+def _bw_to_argb(image: Image):
+  return bytes([x for p in image.getdata()
+                for x in (255, p, p, p)])
+
+
+def _bw_to_rgb(image: Image):
+  return bytes([x for p in image.getdata()
+                for x in (p, p, p)])
+
+
+def _bw_to_rgb565(image: Image):
+  return bytes([(255 if x else 0) for p in image.getdata()
+                for x in (p, p)])
+
+_BW_CONVERTER = {
+  16: _bw_to_rgb565,
+  24: _bw_to_rgb,
+  32: _bw_to_argb,
+}
+
+
+class Framebuf(object):
+  """A framebuffer class.
+
+  This helper class makes it slightly easy to deal with framebuffer
+  """
+
+  def __init__(self, device_node: str):
+    """Initialize a framebuffer object from path to device node."""
+    self.path = device_node
+    fb_name = os.path.basename(device_node)
+    config_dir = '/sys/class/graphics/%s/' % fb_name
+    self.size = tuple(_read_and_convert_to_ints(
+      config_dir + '/virtual_size'))
+    self.stride = _read_and_convert_to_ints(config_dir + '/stride')[0]
+    self.bits_per_pixel = _read_and_convert_to_ints(
+      config_dir + '/bits_per_pixel')[0]
+    assert self.stride == self.bits_per_pixel // 8 * self.size[0]
+
+  def __str__(self):
+    """Make printout prettier."""
+    args = (self.path, self.size, self.stride, self.bits_per_pixel)
+    return "%s  size:%s  stride:%s  bits_per_pixel:%s" % args
+
+  def show(self, image: Image):
+    """Draw image in framebuffer."""
+    assert image.mode == '1', 'only mode 1 is supported'
+    converter = _BW_CONVERTER[self.bits_per_pixel]
+    assert image.size == self.size
+    out = converter(image)
+    with open(self.path, "wb") as fp:
+      fp.write(out)
+
+
+if __name__ == "__main__":
+  parser = argparse.ArgumentParser("Create QR code from file, print to framebuffer.")
+  parser.add_argument('device_node', metavar="device_node", type=str,
+    help='path to framebuffer device node, e.g., /dev/fb0')
+  parser.add_argument('infile', metavar="infile", type=str,
+    help='path to input file to convert to QR code')
+
+  args = parser.parse_args()
+  dev_node = args.device_node
+  infile = args.infile
+
+  tmpfile = tempfile.NamedTemporaryFile(delete=False)
+
+  cat = subprocess.Popen(('cat', infile), stdout=subprocess.PIPE)
+  qrencode_cmd = 'qrencode -t PNG -8 -o ' + tmpfile.name
+  cmd = shlex.split(qrencode_cmd)
+  cmd_io = subprocess.check_output(cmd, stdin=cat.stdout)
+
+  fb = Framebuf(dev_node)
+  print (fb)
+  image = Image.open(tmpfile.name).convert(mode="1")
+  image.thumbnail(fb.size)
+  print (image, image.mode)
+
+  target = Image.new(mode="1", size=fb.size)
+  assert image.size <= target.size
+  # box is represented by upper left corner's coordinates
+  box = ((target.size[0] - image.size[0]) // 2,
+         (target.size[1] - image.size[1]) // 2)
+  target.paste(image, box)
+  fb.show(target)

--- a/live-usb-creator/install_scripts/0_post_install_nochroot
+++ b/live-usb-creator/install_scripts/0_post_install_nochroot
@@ -64,3 +64,4 @@ cp /vagrant/protoc-3.14.0-linux-x86_64.zip /mnt/sysimage/data/app/subzero
 # python wheels for protobuf
 cp /vagrant/protobuf-3.14.0-cp36-cp36m-manylinux1_x86_64.whl /mnt/sysimage/data/app/subzero
 cp /vagrant/six-1.15.0-py2.py3-none-any.whl /mnt/sysimage/data/app/subzero
+cp /vagrant/Pillow-8.3.2-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl /mnt/sysimage/data/app/subzero

--- a/live-usb-creator/live_scripts/install_pillow
+++ b/live-usb-creator/live_scripts/install_pillow
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+###############################################################################
+# Install Python Image Library (PIL) for QR code tool
+###############################################################################
+
+python3 -m pip install \
+  /data/app/subzero/Pillow-8.3.2-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl
+rm -rf /data/app/subzero/Pillow-8.3.2-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl

--- a/live-usb-creator/live_scripts/install_protobuf
+++ b/live-usb-creator/live_scripts/install_protobuf
@@ -8,5 +8,7 @@ unzip -o /data/app/subzero/protoc-3.14.0-linux-x86_64.zip -d /usr bin/protoc
 unzip -o /data/app/subzero/protoc-3.14.0-linux-x86_64.zip -d /usr "include/*"
 rm -rf /data/app/subzero/protoc-3.14.0-linux-x86_64.zip
 
-python3 -m pip install /data/app/subzero/six-1.15.0-py2.py3-none-any.whl /data/app/subzero/protobuf-3.14.0-cp36-cp36m-manylinux1_x86_64.whl
-rm -rf /data/app/subzero/*.whl
+python3 -m pip install /data/app/subzero/six-1.15.0-py2.py3-none-any.whl \
+  /data/app/subzero/protobuf-3.14.0-cp36-cp36m-manylinux1_x86_64.whl
+rm -rf /data/app/subzero/six-1.15.0-py2.py3-none-any.whl \
+  /data/app/subzero/protobuf-3.14.0-cp36-cp36m-manylinux1_x86_64.whl

--- a/live-usb-creator/live_scripts/startup
+++ b/live-usb-creator/live_scripts/startup
@@ -6,6 +6,7 @@
 # Install protobuf and enable sshd, only for dev ISO
 if [ -f "/usr/local/bin/.isotype_dev" ]; then
   /usr/local/bin/install_protobuf
+  /usr/local/bin/install_pillow
   ln -Tsf /bin/python3 /bin/python
   /usr/local/bin/install_nfast_tools_dev
   cp /data/app/subzero/sshd_config /etc/ssh/sshd_config

--- a/live-usb-creator/rhel7-livemedia-dev.ks
+++ b/live-usb-creator/rhel7-livemedia-dev.ks
@@ -371,4 +371,7 @@ vim
 vim-common
 python3
 protobuf-python
+
+# QR tool
+qrencode
 %end


### PR DESCRIPTION
We add a simple utility in the development ISO that converts an input
file into a QR code, and prints the QR code to a framebuffer. The tool
intends to facilitate data backup and transfer on unnetworked subzero
machines.

In this commit, we only add the tool to the development ISO. We may add
it to the release ISO later, if there's a need. All dependencies for
the tool have also been taken care of in this commit.

The tool is available on the live system in path
`/data/app/subzero/tools/bits2qr_fb.py`.

Example:

    echo "Testing bits2qr_fb.py" > test.txt
    /data/app/subzero/tools/bits2qr_fb.py /dev/fb0 test.txt

Synopsis:

    usage: Create QR code from file, print to framebuffer. [-h] device_node infile

    positional arguments:
      device_node  path to framebuffer device node, e.g., /dev/fb0
      infile       path to input file to convert to QR code

    optional arguments:
      -h, --help   show this help message and exit

## Testing

1. Boot up the live ISO with this change
2. Test a small file.
    ```bash
    echo "This is small message to test" > small.txt
    /data/app/subzero/tools/bits2qr_fb.py small.txt
    ```
![small](https://user-images.githubusercontent.com/212987/136248976-0a88a1aa-84c8-4a1e-aeba-05dd59669b88.png)

3. Test a large file.
    ```bash
    head -c 2048 | base64 > big.b64
    /data/app/subzero/tools/bits2qr_fb.py big.b64
    ```
![big b64](https://user-images.githubusercontent.com/212987/136249286-285b9796-9049-4f03-ac5e-5f8ab5fd9c15.png)


