### PR TITLE
Update mkdocs to 1.2.3 in docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,7 +5,7 @@ Jinja2==2.11.3
 livereload==2.6.0
 Markdown==3.0.1
 MarkupSafe==1.1.1
-mkdocs==1.0.4
+mkdocs==1.2.3
 PyYAML==5.4
 singledispatch==3.4.0.3
 six==1.12.0


### PR DESCRIPTION
We get alerted about an security issue (CVE-2021-40978) in mkdocs that's not applicable to subzero production code. We take the opportunity to update the version though.