### PR TITLE
Remove the super destroy call.

### DIFF
--- a/java/shared/src/main/java/com/squareup/subzero/shared/QrSigner.java
+++ b/java/shared/src/main/java/com/squareup/subzero/shared/QrSigner.java
@@ -48,7 +48,6 @@ public class QrSigner implements Destroyable {
      */
     @Override
     public void destroy() throws DestroyFailedException {
-        Destroyable.super.destroy();
         Arrays.fill(this.key, (byte) 0);
         this.is_destroyed = true;
     }

--- a/java/shared/src/test/java/com/squareup/subzero/shared/QrSignerTest.java
+++ b/java/shared/src/test/java/com/squareup/subzero/shared/QrSignerTest.java
@@ -20,7 +20,8 @@ import org.spongycastle.util.encoders.Base64;
 import org.spongycastle.util.encoders.Hex;
 import org.spongycastle.util.io.pem.PemObject;
 import org.spongycastle.util.io.pem.PemReader;
-import org.spongycastle.util.io.pem.PemWriter;;
+import org.spongycastle.util.io.pem.PemWriter;
+import javax.security.auth.DestroyFailedException;
 
 public class QrSignerTest {
 
@@ -53,6 +54,11 @@ public class QrSignerTest {
         System.out.println("public key = " + Hex.toHexString(signer.dumpPublicKey()));
         System.out.println("Signature = " + Hex.toHexString(signature));
         assertThat(Hex.toHexString(signature).equals("63ce6fb96b6ee7c0b488304da55bedbd12dd5c19c15cf047df6af56d64f6316062e6b12842919135f498b7d7a963b14c4192ed489ae24f2fe56274408502dd63"));
+        try {
+            signer.destroy();
+        } catch (DestroyFailedException e){
+            assertThat(false);
+        }
     }
 
     @Test
@@ -76,6 +82,11 @@ public class QrSignerTest {
             assertThat(signer.dumpPublicKey().length == 65);
             assertThat(signature.length == 64);
 
+            try {
+                signer.destroy();
+            } catch (DestroyFailedException e){
+                assertThat(false);
+            }
 
         }catch(NoSuchAlgorithmException | InvalidAlgorithmParameterException | IOException e){
             throw new RuntimeException(e);


### PR DESCRIPTION
That is not correct. There is no super class here.
Default implementation throws DestroyFailedException and makes the
destroy interface unusable.