### PR TITLE
Tooling to compare two releases for bit identical output

### DIFF
--- a/java/gui/src/main/java/com/squareup/subzero/SubzeroGui.java
+++ b/java/gui/src/main/java/com/squareup/subzero/SubzeroGui.java
@@ -8,7 +8,6 @@ import com.squareup.subzero.framebuffer.Framebuffer;
 import com.squareup.subzero.framebuffer.Screens;
 import com.squareup.subzero.ncipher.NCipher;
 import com.squareup.subzero.proto.service.Common;
-import com.squareup.subzero.proto.service.Internal;
 import com.squareup.subzero.proto.service.Service;
 import com.squareup.subzero.proto.service.Service.CommandRequest;
 import com.squareup.subzero.proto.service.Service.CommandResponse;
@@ -20,13 +19,10 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.IllegalFormatException;
 import java.util.List;
 
 import com.squareup.subzero.wallet.WalletLoader;
 import org.bouncycastle.util.encoders.Hex;
-import org.spongycastle.util.encoders.HexEncoder;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 import static com.google.common.io.BaseEncoding.base64;
 
@@ -62,10 +58,10 @@ public class SubzeroGui {
   @Parameter(names = "--signtx-test") public Boolean signtxTest = false;
 
   // Generate a wallet.
-  @Parameter(names = "--generate-wallet") public Boolean genWallet = false;
+  @Parameter(names = "--generate-wallet-files-test") public Boolean genWalletFilesTest = false;
 
   // Sign using wallet.
-  @Parameter(names = "--sign-using-wallet") public Boolean signUsingWallet = false;
+  @Parameter(names = "--sign-using-wallet-files-test") public Boolean signUsingWalletFilesTest = false;
 
   public SubzeroConfig config;
   private Screens screens;
@@ -108,9 +104,9 @@ public class SubzeroGui {
       subzero.uiTest();
     } else if (subzero.signtxTest) {
       subzero.signTxTest();
-    } else if(subzero.genWallet) {
+    } else if(subzero.genWalletFilesTest) {
       subzero.generateWallet();
-    } else if(subzero.signUsingWallet) {
+    } else if(subzero.signUsingWalletFilesTest) {
       subzero.signUsingWallet();
     } else if (subzero.debug != null) {
       subzero.debugMode();
@@ -232,8 +228,7 @@ public class SubzeroGui {
   }
   private void generateWallet() throws Exception {
     WalletLoader  loader  = new WalletLoader();
-    //clean start
-    Files.deleteIfExists(loader.getWalletPath(walletID));
+    loader.ensureDoesNotExist(walletID);
 
 
 
@@ -276,7 +271,8 @@ public class SubzeroGui {
    */
   private void signUsingWallet() throws  Exception {
     WalletLoader loader = new WalletLoader();
-    Files.deleteIfExists(loader.getWalletPath(walletID));
+    loader.ensureDoesNotExist(walletID);
+
     Service.CommandRequest.Builder builder = Service.CommandRequest.newBuilder();
     Service.CommandRequest.SignTxRequest.Builder internalBuilder = Service.CommandRequest.SignTxRequest.newBuilder();
     internalBuilder.setLockTime(0);

--- a/java/gui/src/main/java/com/squareup/subzero/wallet/WalletLoader.java
+++ b/java/gui/src/main/java/com/squareup/subzero/wallet/WalletLoader.java
@@ -71,6 +71,7 @@ public class WalletLoader {
    * @param walletId Integer representation of wallet number.
    * @param wallet data structure to be written.
    * @param hsmNumber hsmNumber representing which HSM out of the 4 generated this wallet.
+   * @param prefix Directory name to save the wallet file in.
    * @throws IOException
    */
   public void saveNumbered(int walletId, Wallet wallet, int hsmNumber, String prefix) throws IOException{
@@ -91,6 +92,7 @@ public class WalletLoader {
    * Note: Only for testing.
    * @param walletId
    * @param hsmNumber
+   * @param prefix Directory name to load the wallet file from.
    * @throws IOException
    */
   public Wallet loadNumbered(int walletId, int hsmNumber, String prefix)  throws IOException{

--- a/java/gui/src/main/java/com/squareup/subzero/wallet/WalletLoader.java
+++ b/java/gui/src/main/java/com/squareup/subzero/wallet/WalletLoader.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.StringReader;
 import java.nio.file.FileSystems;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static com.google.common.base.Charsets.UTF_8;
@@ -75,6 +76,7 @@ public class WalletLoader {
   public void saveNumbered(int walletId, Wallet wallet, int hsmNumber, String prefix) throws IOException{
     Path path = directory.resolve(format("%s/subzero-%d.wallet-%d", prefix, walletId, hsmNumber));
     System.out.println(format("Saving wallet file to: %s", path));
+    Files.createDirectories(directory.resolve(prefix));
     FileOutputStream fos = new FileOutputStream(path.toFile());
     OutputStreamWriter osw = new OutputStreamWriter(fos, UTF_8);
 

--- a/java/gui/src/main/java/com/squareup/subzero/wallet/WalletLoader.java
+++ b/java/gui/src/main/java/com/squareup/subzero/wallet/WalletLoader.java
@@ -64,6 +64,41 @@ public class WalletLoader {
 
     // TODO: save to USB backup drive
   }
+  /**
+   * Utility method for generate wallet test.
+   * Note: Only for testing.
+   * @param walletId Integer representation of wallet number.
+   * @param wallet data structure to be written.
+   * @param hsmNumber hsmNumber representing which HSM out of the 4 generated this wallet.
+   * @throws IOException
+   */
+  public void saveNumbered(int walletId, Wallet wallet, int hsmNumber, String prefix) throws IOException{
+    Path path = directory.resolve(format("%s/subzero-%d.wallet-%d", prefix, walletId, hsmNumber));
+    System.out.println(format("Saving wallet file to: %s", path));
+    FileOutputStream fos = new FileOutputStream(path.toFile());
+    OutputStreamWriter osw = new OutputStreamWriter(fos, UTF_8);
+
+    // We save the wallet in JSON format, because it's simpler if we need to fix anything manually.
+    JsonFormat.printer().preservingProtoFieldNames().omittingInsignificantWhitespace().appendTo(wallet, osw);
+    osw.flush();
+    fos.getFD().sync();
+  }
+
+  /**
+   * Utility method to load a specific wallet with for a specific hsm number.
+   * Note: Only for testing.
+   * @param walletId
+   * @param hsmNumber
+   * @throws IOException
+   */
+  public Wallet loadNumbered(int walletId, int hsmNumber, String prefix)  throws IOException{
+    Path path = directory.resolve(format("%s/subzero-%d.wallet-%d", prefix, walletId, hsmNumber));
+    System.out.println(format("Loading wallet file from: %s", path));
+    FileReader fr = new FileReader(path.toFile());
+    Wallet.Builder wallet = Wallet.newBuilder();
+    JsonFormat.parser().merge(fr, wallet);
+    return wallet.build();
+  }
 
   public Wallet load(int walletId) throws IOException {
     Path path = getWalletPath(walletId);
@@ -93,7 +128,7 @@ public class WalletLoader {
   /**
    * Path to folder which contains the wallet files.
    */
-  private Path getWalletPath(int walletId) {
+  public Path getWalletPath(int walletId) {
     // Check that the marker file exists.
     Path marker = directory.resolve(MARKER_FILE);
     if (!marker.toFile().exists()) {


### PR DESCRIPTION
The big idea here is to reduce the manual steps in release verification as much as possible.
This PR has two commits:
1. First one adds a command line option to be able to generate a wallet using just one HSM without any manual copying of files.
2. Second one adds a command line option to sign using the generated wallet.

This makes the below things easier than before:
1. Exercising the create wallet flow.
2. Signing using a new wallet and using all nodes that would be involved.
3. Comparing deterministic signatures on real hsm hardware release over release.
4. Creating wallets and using any release and signing the same transaction with multiple releases and match the output bit for bit.
