### PR TITLE
Remove dependabot badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Integration Test](https://github.com/square/subzero/actions/workflows/signtx-test.yml/badge.svg)](https://github.com/square/subzero/actions/workflows/signtx-test.yml)
 
 [![Documentation Status](https://readthedocs.org/projects/subzero/badge/?version=master)](https://subzero.readthedocs.io/en/master/?badge=master)
-[![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=square/subzero)](https://dependabot.com)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/square/subzero/blob/master/LICENSE)
 
 <img src="logo.png" width="100">


### PR DESCRIPTION
This badge has been deprecated.