### PR TITLE
Nmahendru/bitcoinj 0 16 update tweek

### DIFF
--- a/java/shared/pom.xml
+++ b/java/shared/pom.xml
@@ -60,6 +60,14 @@
       <groupId>org.bitcoinj</groupId>
       <artifactId>bitcoinj-core</artifactId>
       <version>0.16</version>
+      <!--Excluding protobuf-lite(newly added in 0.16 bitcoinj-core) as subzero uses protobuf-java-->
+      <!--As per https://github.com/protocolbuffers/protobuf/issues/8104, lite and non lite cannot coexist-->
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.protobuf</groupId>
+          <artifactId>protobuf-javalite</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 

--- a/java/shared/pom.xml
+++ b/java/shared/pom.xml
@@ -59,7 +59,7 @@
     <dependency>
       <groupId>org.bitcoinj</groupId>
       <artifactId>bitcoinj-core</artifactId>
-      <version>0.15.10</version>
+      <version>0.16</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
   This is an attempt to fix the error in this PR:
       https://github.com/square/subzero/pull/440   


    bitcoinj-core 0.16 adds protobuf-javalite from the classpath
    by default. Subzero uses protobuf-java as a dependency already.

    Updating bitcoinj-core causes runtime failures as listed below:
    java.lang.NoSuchMethodError: 'com.google.protobuf.Descriptors$Descriptor com.google.protobuf.Any.getDescriptor()'

    This is because protobuf-javalite and protobuf-java are not ABI
    compatible by definition.
    The lite version seems to be used for android builds to reduce the
    artefact size. For subzero we don't need that.