### PR TITLE
Upgrade protobuffer compiler to v21.0

### DIFF
--- a/scripts/ubuntu_install_protobuf.sh
+++ b/scripts/ubuntu_install_protobuf.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-PROTOC_ZIP="protoc-3.14.0-linux-x86_64.zip"
-
+PROTO_VERSION="21.0"
+PROTOC_ZIP="protoc-${PROTO_VERSION}-linux-x86_64.zip"
 cd /tmp
 sudo apt-get update
 sudo apt-get install libtool curl make g++ unzip -y
-curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v3.14.0/$PROTOC_ZIP
+curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v${PROTO_VERSION}/${PROTOC_ZIP}
 sudo unzip -o $PROTOC_ZIP -d /usr/local bin/protoc
 sudo unzip -o $PROTOC_ZIP -d /usr/local 'include/*'
 sudo chmod 755 /usr/local/bin/protoc
@@ -14,4 +14,4 @@ sudo chmod -R 755 /usr/local/include
 # For debugging
 protoc --version
 python -m pip install --upgrade pip
-python -m pip install protobuf
+python -m pip install protobuf==4.21.1


### PR DESCRIPTION
This is to resolve a compatibility issue related to a protobuffer python
update v4.21.0
(https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates).

We also pin the protobuf python version to v4.21.1, to make this more
explict.