### PR TITLE
fix(sec): upgrade mkdocs to 

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,7 +5,7 @@ Jinja2==3.0.2
 Markdown==3.3.4
 MarkupSafe==2.0.1
 mergedeep==1.3.4
-mkdocs==1.2.3
+mkdocs==1.3.0
 packaging==21.2
 pyparsing==2.4.7
 python-dateutil==2.8.2


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in mkdocs 1.2.3
- [MPS-2022-6935](https://www.oscs1024.com/hd/MPS-2022-6935)


### What did I do？
Upgrade mkdocs from 1.2.3 to  for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS