### PR TITLE
fix(sec): upgrade certifi to 

### DIFF
--- a/utils/requirements.txt
+++ b/utils/requirements.txt
@@ -1,4 +1,4 @@
-certifi==2020.12.5
+certifi==2022.12.07
 chardet==4.0.0
 idna==2.10
 requests==2.25.1


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in certifi 2020.12.5
- [CVE-2022-23491](https://www.oscs1024.com/hd/CVE-2022-23491)


### What did I do？
Upgrade certifi from 2020.12.5 to  for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS