### PR TITLE
Specify protoc version when building protos

### DIFF
--- a/java/proto/pom.xml
+++ b/java/proto/pom.xml
@@ -15,13 +15,14 @@
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
+    <protoBufVersion>3.21.5</protoBufVersion>
   </properties>
 
   <dependencies>
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>3.21.5</version>
+      <version>${protoBufVersion}</version>
     </dependency>
   </dependencies>
 
@@ -38,6 +39,7 @@
               <goal>run</goal>
             </goals>
             <configuration>
+              <protocVersion>${protoBufVersion}</protocVersion>
               <addProtoSources>all</addProtoSources>
               <inputDirectories>
                 <include>src/main/proto</include>


### PR DESCRIPTION
And update to the latest version. Apple started releasing the osx aarch64 (M1) version in 3.17.3
[link](https://github.com/os72/protoc-jar-maven-plugin/issues/129)

This is a fix for this error on M1 builds:
[ERROR] Failed to execute goal com.github.os72:protoc-jar-maven-plugin:3.11.4:run (default) on project proto: Error extracting protoc for version 3.11.4: Unsupported platform: protoc-3.11.4-osx-aarch_64.exe -> [Help 1]