### PR TITLE
Fix clang static analysis

### DIFF
--- a/scripts/sa_check_core.sh
+++ b/scripts/sa_check_core.sh
@@ -20,6 +20,7 @@ fi
 grep file "${COMPILE_DB}" |
 awk '{ print $2; }' |
 sed 's/\"//g' |
+sed 's/,//g' |
 while read FILE; do
   if ! grep -q ${EXCLUDE_PATH_PATTERN} <<< "${FILE}"; then
     cd $(dirname ${FILE});


### PR DESCRIPTION
The file names had trailing commas, which of course broke. Let's see if stripping the commas fixes the issue.