### PR TITLE
Update nanopb submodule to release 0.4.7.

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.14.0)
 project (subzero)
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -pedantic -Wextra -Wwrite-strings -Wstrict-prototypes -Wmissing-prototypes -Wcast-qual -std=gnu11 -DPB_FIELD_16BIT")

--- a/core/src/rpc.c
+++ b/core/src/rpc.c
@@ -51,7 +51,7 @@ static Result populate_internal_command(InternalCommandRequest * to){
   CommandRequest from = CommandRequest_init_default;
   // Cannot use pb_decode_delimited as on the coordinator service the java code is generating bytes
   // without the delimited values.
-  if(!pb_decode(&pb_command, CommandRequest_fields, &from)){
+  if (!pb_decode(&pb_command, &CommandRequest_msg, &from)) {
     res = Result_COMMAND_DECODE_FAILED;
     ERROR("Could not decode input bytes for command request.");
     goto cleanup;
@@ -96,7 +96,7 @@ static void handle_error(pb_istream_t * input, pb_ostream_t * output, Result err
   snprintf(out.response.Error.message, sizeof(out.response.Error.message),
             "%s: %s", error_message, PB_GET_ERROR(input));
   out.response.Error.has_message = true;
-  if (!pb_encode_delimited(output, InternalCommandResponse_fields, &out)) {
+  if (!pb_encode_delimited(output, &InternalCommandResponse_msg, &out)) {
     ERROR("Encoding error message about decoding failed: %s",
           PB_GET_ERROR(output));
   }
@@ -108,7 +108,7 @@ void handle_incoming_message(pb_istream_t *input, pb_ostream_t *output) {
   InternalCommandRequest cmd = InternalCommandRequest_init_default;
   InternalCommandResponse out = InternalCommandResponse_init_default;
 
-  if (!pb_decode_delimited(input, InternalCommandRequest_fields, &cmd)) {
+  if (!pb_decode_delimited(input, &InternalCommandRequest_msg, &cmd)) {
     handle_error(input, output, Result_COMMAND_DECODE_FAILED, "Decode Input failed");
     return;
   }
@@ -126,7 +126,7 @@ void handle_incoming_message(pb_istream_t *input, pb_ostream_t *output) {
   }
   execute_command(&cmd, &out);
 
-  if (!pb_encode_delimited(output, InternalCommandResponse_fields, &out)) {
+  if (!pb_encode_delimited(output, &InternalCommandResponse_msg, &out)) {
     handle_error(input, output, Result_COMMAND_ENCODE_FAILED, "Encoding failed");
     return;
   }


### PR DESCRIPTION
This resolves several issues:
- nanopb 0.4.7 works out of the box with python 3.11.x
- nanopb tests work with python 3.11.x
- the C code generated by nanopb no longer has unaligned access issues, so specifying MACOSX_DEPLOYMENT_TARGET=11 on an M1 Apple Macbook is not needed.
- fuzz testing with UBSAN found a bug in the old version of nanopb, this does not reproduce with nanopb 0.4.7