### PR TITLE
Fix overflow bug in conv_btc_to_satoshi()

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -53,6 +53,7 @@ set(main_SRC
 set(checks_SRC
     "src/checks/bip32.c"
     "src/checks/check_sign_tx.c"
+    "src/checks/conv_checks.c"
     "src/checks/self_checks.c"
     "src/checks/validate_fees.c"
     "src/checks/verify_mix_entropy.c"

--- a/core/include/checks.h
+++ b/core/include/checks.h
@@ -31,6 +31,7 @@ int verify_mix_entropy(void);
 int verify_protect_pubkey(void);
 int verify_no_rollback(void);
 int verify_check_qrsignature_pub(void);
+int verify_conv_btc_to_satoshi(void);
 
 #define ASSERT_STR_EQUAL(value, expecting, message) \
   do {                                              \

--- a/core/src/checks/conv_checks.c
+++ b/core/src/checks/conv_checks.c
@@ -1,0 +1,47 @@
+#include <inttypes.h>
+#include <stdint.h>
+
+#include "checks.h"
+#include "conv.h"
+#include "log.h"
+
+int verify_conv_btc_to_satoshi(void) {
+  uint32_t btc = 0;
+  uint64_t satoshi = conv_btc_to_satoshi(btc);
+  uint64_t expected = 0;
+  if (satoshi != expected) {
+    ERROR("%s: conv_btc_to_satoshi(%" PRIu32 ") returned %" PRIu64 " (expected: %" PRIu64 ")",
+          __func__,
+          btc,
+          satoshi,
+          expected);
+    return -1;
+  }
+
+  btc = 1;
+  satoshi = conv_btc_to_satoshi(btc);
+  expected = 100000000ull;
+  if (satoshi != expected) {
+    ERROR("%s: conv_btc_to_satoshi(%" PRIu32 ") returned %" PRIu64 " (expected: %" PRIu64 ")",
+          __func__,
+          btc,
+          satoshi,
+          expected);
+    return -1;
+  }
+
+  btc = 21000000; // ~21 million BTC is the most that will ever be mined
+  satoshi = conv_btc_to_satoshi(btc);
+  expected = 2100000000000000ull;
+  if (satoshi != expected) {
+    ERROR("%s: conv_btc_to_satoshi(%" PRIu32 ") returned %" PRIu64 " (expected: %" PRIu64 ")",
+          __func__,
+          btc,
+          satoshi,
+          expected);
+    return -1;
+  }
+
+  INFO("verify_conv_btc_to_satoshi: ok");
+  return 0;
+}

--- a/core/src/checks/self_checks.c
+++ b/core/src/checks/self_checks.c
@@ -62,6 +62,12 @@ int run_self_checks(void) {
     ERROR("self check failure: verify_no_rollback failed.");
   }
 
+  t = verify_conv_btc_to_satoshi();
+  if (t != 0) {
+    r = -1;
+    ERROR("self check failure: verify_conv_btc_to_satoshi failed.");
+  }
+
   // environment specific additional checks + cleanup
   t = post_run_self_checks();
   if (t != 0) {

--- a/core/src/conv.c
+++ b/core/src/conv.c
@@ -1,3 +1,5 @@
 #include "conv.h"
 
-uint64_t conv_btc_to_satoshi(uint32_t btc) { return btc * 100000000; }
+uint64_t conv_btc_to_satoshi(uint32_t btc) {
+    return (uint64_t) btc * 100000000ull;
+}


### PR DESCRIPTION
There was an unsigned integer overflow bug in conv_btc_to_satoshi(). This didn't matter in practice because at the moment the function is never called with large BTC inputs, but it's still a good idea to fix it just in case this ever changes in the future.

Added a new self-check and verified that it fails w/o the change to conv.c and passes with the change to conv.c.