### PR TITLE
[Cleanup] const read-only input pointers

### DIFF
--- a/core/include/init_wallet.h
+++ b/core/include/init_wallet.h
@@ -7,4 +7,4 @@
 #include "config.h"
 
 Result mix_entropy(uint8_t wallet_entropy[static MASTER_SEED_SIZE],
-                   InternalCommandRequest *in);
+                   const InternalCommandRequest* const in);

--- a/core/include/protection.h
+++ b/core/include/protection.h
@@ -16,7 +16,7 @@ Result protect_pubkey(char xpub[static XPUB_SIZE],
 /**
  * Decrypt encrypted_pub_key with pubkey encryption key.
  */
-Result expose_pubkey(EncryptedPubKey *encrypted_pub_key,
+Result expose_pubkey(const EncryptedPubKey* const encrypted_pub_key,
                      char xpub[static XPUB_SIZE]);
 
 /**
@@ -31,5 +31,5 @@ Result protect_wallet(uint8_t master_seed[static MASTER_SEED_SIZE],
  * Decrypt master_seed with master_seed_encryption_key. In dev, we XOR with a
  * magic byte.
  */
-Result expose_wallet(EncryptedMasterSeed *encrypted_master_seed,
+Result expose_wallet(const EncryptedMasterSeed* const encrypted_master_seed,
                      uint8_t master_seed[static MASTER_SEED_SIZE]);

--- a/core/include/rpc.h
+++ b/core/include/rpc.h
@@ -5,11 +5,13 @@
 
 void handle_incoming_message(pb_istream_t *input, pb_ostream_t *output);
 
-Result handle_init_wallet(InternalCommandRequest *,
-                          InternalCommandResponse_InitWalletResponse *);
+Result handle_init_wallet(
+    const InternalCommandRequest* const in,
+    InternalCommandResponse_InitWalletResponse *out);
 
-Result handle_finalize_wallet(InternalCommandRequest_FinalizeWalletRequest *,
-                              InternalCommandResponse_FinalizeWalletResponse *);
+Result handle_finalize_wallet(
+    const InternalCommandRequest_FinalizeWalletRequest* const in,
+    InternalCommandResponse_FinalizeWalletResponse *out);
 
-Result pre_execute_command(InternalCommandRequest *in);
+Result pre_execute_command(const InternalCommandRequest* const in);
 void post_execute_command(void);

--- a/core/include/sign.h
+++ b/core/include/sign.h
@@ -1,6 +1,7 @@
 #pragma once
 
-Result handle_sign_tx(InternalCommandRequest_SignTxRequest *,
-                      InternalCommandResponse_SignTxResponse *);
+Result handle_sign_tx(
+    const InternalCommandRequest_SignTxRequest* const request,
+    InternalCommandResponse_SignTxResponse *response);
 
-bool validate_fees(InternalCommandRequest_SignTxRequest *request);
+bool validate_fees(const InternalCommandRequest_SignTxRequest* const request);

--- a/core/src/dev/execute_command_hooks.c
+++ b/core/src/dev/execute_command_hooks.c
@@ -2,7 +2,7 @@
 
 #include "rpc.h"
 
-Result pre_execute_command(InternalCommandRequest *in) {
+Result pre_execute_command(const InternalCommandRequest* const in) {
   (void)in;
   return Result_SUCCESS;
 }

--- a/core/src/dev/init_wallet.c
+++ b/core/src/dev/init_wallet.c
@@ -34,7 +34,7 @@
  *   - derive the pubkey
  *   - encrypt the master_seed and pubkey
  */
-Result handle_init_wallet(InternalCommandRequest *in,
+Result handle_init_wallet(const InternalCommandRequest* const in,
                           InternalCommandResponse_InitWalletResponse *out) {
 
   uint8_t entropy[MASTER_SEED_SIZE] = {0};

--- a/core/src/finalize_wallet.c
+++ b/core/src/finalize_wallet.c
@@ -10,8 +10,9 @@
 #include "strlcpy.h"
 
 Result
-handle_finalize_wallet(InternalCommandRequest_FinalizeWalletRequest *in,
-                       InternalCommandResponse_FinalizeWalletResponse *out) {
+handle_finalize_wallet(
+    const InternalCommandRequest_FinalizeWalletRequest* const in,
+    InternalCommandResponse_FinalizeWalletResponse *out) {
   if (in->encrypted_pub_keys_count != MULTISIG_PARTS) {
     ERROR("expecting %d encrypted_pub_keys, received %d.", MULTISIG_PARTS,
           in->encrypted_pub_keys_count);

--- a/core/src/init_wallet.c
+++ b/core/src/init_wallet.c
@@ -9,7 +9,7 @@
  * TODO(alok): replace with HMAC, which is slightly better.
  */
 Result mix_entropy(uint8_t master_seed[static MASTER_SEED_SIZE],
-                   InternalCommandRequest *in) {
+                   const InternalCommandRequest* const in) {
   if (in->command.InitWallet.random_bytes.size != MASTER_SEED_SIZE) {
     ERROR("unexpected random_bytes.size");
     return Result_INCORRECT_RANDOM_BYTES_SIZE;

--- a/core/src/ncipher/execute_command_hooks.c
+++ b/core/src/ncipher/execute_command_hooks.c
@@ -29,7 +29,7 @@ extern M_KeyID pub_key_encryption_key;
 /**
  * Load keys using tickets.
  */
-Result pre_execute_command(InternalCommandRequest *in) {
+Result pre_execute_command(const InternalCommandRequest* const in) {
   DEBUG("in pre_execute_command");
 
   if (!in->has_master_seed_encryption_key_ticket) {

--- a/core/src/ncipher/init_wallet.c
+++ b/core/src/ncipher/init_wallet.c
@@ -41,7 +41,7 @@ static Result gen_random(uint8_t *buffer, uint32_t buffer_len);
  *   - derive the pubkey
  *   - encrypt the master_seed and pubkey
  */
-Result handle_init_wallet(InternalCommandRequest *in,
+Result handle_init_wallet(const InternalCommandRequest* const in,
                           InternalCommandResponse_InitWalletResponse *out) {
   DEBUG("in handle_init_wallet");
 

--- a/core/src/protect.c
+++ b/core/src/protect.c
@@ -47,7 +47,7 @@ Result protect_pubkey(char xpub[static XPUB_SIZE],
 /**
  * Decrypt encrypted_pub_key with pubkey encryption key.
  */
-Result expose_pubkey(EncryptedPubKey *encrypted_pub_key,
+Result expose_pubkey(const EncryptedPubKey* const encrypted_pub_key,
                      char xpub[static XPUB_SIZE]) {
   if (pub_key_encryption_key == 0) {
     ERROR("pub_key_encryption_key not initialized");
@@ -122,7 +122,7 @@ Result protect_wallet(uint8_t master_seed[static MASTER_SEED_SIZE],
 /**
  * Decrypt master_seed with master_seed_encryption_key.
  */
-Result expose_wallet(EncryptedMasterSeed *encrypted_master_seed,
+Result expose_wallet(const EncryptedMasterSeed* const encrypted_master_seed,
                      uint8_t master_seed[static MASTER_SEED_SIZE]) {
   if (master_seed_encryption_key == 0) {
     ERROR("master_seed_encryption_key not initialized");

--- a/core/src/rpc.c
+++ b/core/src/rpc.c
@@ -12,10 +12,10 @@
 #include "sign.h"
 #include "qrsignatures.h"
 
-static void execute_command(InternalCommandRequest *,
-                            InternalCommandResponse *);
+static void execute_command(const InternalCommandRequest* const cmd,
+                            InternalCommandResponse *out);
 
-static int check_version(InternalCommandRequest *cmd) {
+static int check_version(const InternalCommandRequest* const cmd) {
   if (VERSION != cmd->version) {
     ERROR("Version mismatch. Expecting %d, got %d.", VERSION, cmd->version);
     return false;
@@ -129,7 +129,7 @@ void handle_incoming_message(pb_istream_t *input, pb_ostream_t *output) {
 }
 
 // execute command
-static void execute_command(InternalCommandRequest *cmd,
+static void execute_command(const InternalCommandRequest* const cmd,
                             InternalCommandResponse *out) {
   if (!check_version(cmd)) {
     out->which_response = InternalCommandResponse_Error_tag;


### PR DESCRIPTION
Read-only input pointer arguments to functions should be const. This improves readability and helps avoid accidental bugs.