### PR TITLE
Fix portability issue in format string specifier

### DIFF
--- a/core/src/checks/check_sign_tx.c
+++ b/core/src/checks/check_sign_tx.c
@@ -122,7 +122,7 @@ int verify_sign_tx(void) {
     return -1;
   }
   if (resp.signatures[0].der.size != sizeof(expected_der)) {
-    ERROR("unexpected der_len: %d != %ld.", resp.signatures[0].der.size,
+    ERROR("unexpected der_len: %d != %zu.", resp.signatures[0].der.size,
           sizeof(expected_der));
     return -1;
   }


### PR DESCRIPTION
Format string specifier for size_t fields should be "%zu".

Discovered when building the code for a non-nCipher 32-bit big-endian architecture.