### PR TITLE
Use memset_s() in memzero() if it is available

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -3,6 +3,12 @@ project (subzero)
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -pedantic -Wextra -Wwrite-strings -Wstrict-prototypes -Wmissing-prototypes -Wcast-qual -std=gnu11 -DPB_FIELD_16BIT")
 
+include(CheckSymbolExists)
+check_symbol_exists(memset_s "string.h" CONFIG_HAVE_MEMSET_S)
+if (CONFIG_HAVE_MEMSET_S)
+  add_definitions("-DCONFIG_HAVE_MEMSET_S=1")
+endif ()
+
 # Part 1/2 of magic to drop the full path from __FILE__
 string(LENGTH "${CMAKE_SOURCE_DIR}/" SOURCE_PATH_SIZE)
 add_definitions("-DSOURCE_PATH_SIZE=${SOURCE_PATH_SIZE}")
@@ -81,6 +87,7 @@ set(checks_SRC
     "src/checks/bip32.c"
     "src/checks/check_sign_tx.c"
     "src/checks/conv_checks.c"
+    "src/checks/memzero_checks.c"
     "src/checks/self_checks.c"
     "src/checks/validate_fees.c"
     "src/checks/verify_mix_entropy.c"

--- a/core/include/checks.h
+++ b/core/include/checks.h
@@ -33,6 +33,11 @@ int verify_no_rollback(void);
 int verify_check_qrsignature_pub(void);
 int verify_conv_btc_to_satoshi(void);
 
+/**
+ * Checks that the memzero() function erases memory as expected.
+ */
+int verify_memzero(void);
+
 #define ASSERT_STR_EQUAL(value, expecting, message) \
   do {                                              \
     if (strcmp(expecting, value) != 0) {            \

--- a/core/src/checks/memzero_checks.c
+++ b/core/src/checks/memzero_checks.c
@@ -1,0 +1,19 @@
+#include "checks.h"
+#include "log.h"
+#include "memzero.h"
+
+#include <assert.h>
+#include <string.h>
+
+int verify_memzero(void) {
+  uint8_t buf[16] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
+  memzero(buf, sizeof(buf));
+  uint8_t zero_buf[16] = { 0 };
+  static_assert(sizeof(buf) == sizeof(zero_buf), "sizeof(buf) must equal sizeof(zero_buf)");
+  if (memcmp(buf, zero_buf, sizeof(buf)) != 0) {
+    ERROR("%s: memzero() failed to zero memory region", __func__);
+    return -1;
+  }
+  INFO("%s: ok", __func__);
+  return 0;
+}

--- a/core/src/checks/self_checks.c
+++ b/core/src/checks/self_checks.c
@@ -68,6 +68,12 @@ int run_self_checks(void) {
     ERROR("self check failure: verify_conv_btc_to_satoshi failed.");
   }
 
+  t = verify_memzero();
+  if (t != 0) {
+    r = -1;
+    ERROR("self check failure: verify_memzero failed.");
+  }
+
   // environment specific additional checks + cleanup
   t = post_run_self_checks();
   if (t != 0) {

--- a/core/src/memzero.c
+++ b/core/src/memzero.c
@@ -1,6 +1,22 @@
-#include <stdint.h>
-
 #include "memzero.h"
+
+#ifdef CONFIG_HAVE_MEMSET_S
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include "log.h"
+
+void memzero(void* s, size_t n) {
+  int res = memset_s(s, n, 0, n);
+  if (res != 0) {
+    ERROR("memset_s() failed with error code %d: %s", (int) res, strerror(res));
+    abort(); // unsafe to continue, terminate the program
+  }
+}
+
+#else
+
+#include <stdint.h>
 
 /**
  * This function MUST NEVER be included in a file with any other functions.
@@ -20,3 +36,5 @@ void memzero(void *s, size_t n) {
     ptr++;
   }
 }
+
+#endif


### PR DESCRIPTION
Tested with:
- Apple Clang on Mac OS (where memset_s() is available)
- GCC on Linux (where memset_s() is not available)