### PR TITLE
[core] self check that BYTE_ORDER is defined correctly

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -81,6 +81,7 @@ set(checks_SRC
     "src/checks/bip32.c"
     "src/checks/check_sign_tx.c"
     "src/checks/conv_checks.c"
+    "src/checks/misc_checks.c"
     "src/checks/self_checks.c"
     "src/checks/validate_fees.c"
     "src/checks/verify_mix_entropy.c"

--- a/core/include/checks.h
+++ b/core/include/checks.h
@@ -24,6 +24,12 @@ int pre_run_self_checks(void);
  */
 int post_run_self_checks(void);
 
+/**
+ * Checks if the machine is little-endian or big-endian, and verifies that the
+ * result matches the BYTE_ORDER preprocessor constant.
+ */
+int verify_byte_order(void);
+
 int verify_bip32(void);
 int verify_sign_tx(void);
 int verify_validate_fees(void);

--- a/core/src/checks/misc_checks.c
+++ b/core/src/checks/misc_checks.c
@@ -1,0 +1,27 @@
+#include "checks.h"
+#include "log.h"
+
+#include <sha2.h>
+#include <stdint.h>
+
+int verify_byte_order(void) {
+  union {
+    uint8_t bytes[sizeof(uint32_t) / sizeof(uint8_t)];
+    uint32_t word;
+  } u;
+  u.word = 1;
+  const bool is_little_endian = (u.bytes[0] == (uint8_t) 1);
+#if BYTE_ORDER == LITTLE_ENDIAN
+  if (!is_little_endian) {
+    ERROR("%s: detected byte order is big-endian, but -DBYTE_ORDER=4321 is not defined", __func__);
+    return -1;
+  }
+#else // if BYTE_ORDER == BIG_ENDIAN
+  if (is_little_endian) {
+    ERROR("%s: detected byte order is little-endian, but -DBYTE_ORDER=4321 is defined", __func__);
+    return -1;
+  }
+#endif
+  INFO("%s: ok", __func__);
+  return 0;
+}

--- a/core/src/checks/self_checks.c
+++ b/core/src/checks/self_checks.c
@@ -21,6 +21,12 @@ int run_self_checks(void) {
     return r;
   }
 
+  t = verify_byte_order();
+  if (t != 0) {
+    r = -1;
+    ERROR("verify_byte_order failed.");
+  }
+
   t = verify_mix_entropy();
   if (t != 0) {
     r = -1;


### PR DESCRIPTION
If BYTE_ORDER is defined incorrectly then trezor-crypto's SHA2 functions will give the wrong results.
That's hard to debug.
This diff adds an explicit check to make sure the defined BYTE_ORDER matches the byte order detected at runtime.