### PR TITLE
[core] improve verify_check_qrsignature_pub()

### DIFF
--- a/core/src/qrsignatures.c
+++ b/core/src/qrsignatures.c
@@ -30,6 +30,10 @@ bool check_qrsignature_pub(const uint8_t * const data, size_t data_len, const ui
     ERROR("Signature is null");
     return false;
   }
+  if (pub == NULL) {
+    ERROR("pub is null.");
+    return false;
+  }
 
   
   int result_verify = ecdsa_verify(


### PR DESCRIPTION
Add more negative test cases:
- null data
- zero length data
- null signature
- null public key
- corrupted public key