### PR TITLE
[core] fix build break when cross-compiling for nCipher target

### DIFF
--- a/core/src/checks/self_checks.c
+++ b/core/src/checks/self_checks.c
@@ -12,7 +12,7 @@ typedef struct self_check_function_info {
 } self_check_function_info;
 
 #define MAX_SELF_CHECKS ((size_t) 128)
-static self_check_function_info self_checks[MAX_SELF_CHECKS] = { 0 };
+static self_check_function_info self_checks[MAX_SELF_CHECKS] = { { 0 } };
 static size_t self_checks_count = 0;
 static bool self_checks_registered = false;
 


### PR DESCRIPTION
Apparently, the nCipher GCC compiler is more strict about the syntax that it accepts.