### PR TITLE
[core] improve coverage of verify_protect_pubkey() and fix a bug in dev/aes_gcm.c

### DIFF
--- a/core/src/dev/aes_gcm.c
+++ b/core/src/dev/aes_gcm.c
@@ -84,6 +84,7 @@ Result aes_gcm_encrypt(M_KeyID keyId, uint8_t * plaintext, size_t plaintext_len,
 
   // Encrypt plaintext.
   memcpy(aes_gcm_buffer, plaintext, plaintext_len);
+  memzero(plaintext, plaintext_len);
 
   if (RETURN_GOOD != gcm_encrypt_message(iv, sizeof(iv),
                                          NULL, 0, // empty header
@@ -99,6 +100,7 @@ Result aes_gcm_encrypt(M_KeyID keyId, uint8_t * plaintext, size_t plaintext_len,
   if (RETURN_GOOD != gcm_end(ctx))
   {
     ERROR("gcm_end failed");
+    memzero(aes_gcm_buffer, sizeof(aes_gcm_buffer));
     return Result_UNKNOWN_INTERNAL_FAILURE;
   }
 

--- a/core/src/protect.c
+++ b/core/src/protect.c
@@ -9,6 +9,11 @@ Result protect_pubkey(char xpub[static XPUB_SIZE],
   // This is extremely hacky, but works. ¯\_(ツ)_/¯
   printf(MAGIC);
 
+  if (NULL == encrypted_pub_key) {
+    ERROR("%s: null encrypted_pub_key input", __func__);
+    return Result_UNKNOWN_INTERNAL_FAILURE;
+  }
+
   static_assert(sizeof(encrypted_pub_key->encrypted_pub_key.bytes) >=
                 XPUB_SIZE + 12 + 16,
                 "misconfigured encrypted_pub_key max size");
@@ -52,6 +57,11 @@ Result expose_pubkey(const EncryptedPubKey* const encrypted_pub_key,
   if (pub_key_encryption_key == 0) {
     ERROR("pub_key_encryption_key not initialized");
     return Result_EXPOSE_PUBKEY_NO_PUBKEY_ENCRYPTION_KEY_FAILURE;
+  }
+
+  if (NULL == encrypted_pub_key) {
+    ERROR("%s: null encrypted_pub_key input", __func__);
+    return Result_UNKNOWN_INTERNAL_FAILURE;
   }
 
   if (!encrypted_pub_key->has_encrypted_pub_key) {


### PR DESCRIPTION
Added more self checks which improve code coverage. Discovered that dev/aes_gcm.c didn't properly memzero() the plaintext, despite what the comments claimed. Fixed the bug so the memzero() behavior is consistent across dev and ncipher versions of aes_gcm logic.