### PR TITLE
[core] clang-format the include order + fix resulting build breaks

### DIFF
--- a/core/include/aes_gcm_dev.h
+++ b/core/include/aes_gcm_dev.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <squareup/subzero/internal.pb.h>
+#include <stddef.h>
+#include <stdint.h>
+
 /* This header is meant for the dev target, and should only be included in the
  * dev implementation */
 

--- a/core/include/aes_gcm_ncipher.h
+++ b/core/include/aes_gcm_ncipher.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <nfastapp.h>
+#include <squareup/subzero/internal.pb.h>
+#include <stddef.h>
+#include <stdint.h>
+
 /* This header is meant for the nCipher target, and should only be included in the
  * codesafe/ncipher implementation */
 

--- a/core/include/print.h
+++ b/core/include/print.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <stddef.h>
+#include <stdint.h>
+
 void print_uint8(uint8_t value);
 void print_uint16(uint16_t value);
 void print_uint32(uint32_t value);

--- a/core/include/qrsignatures.h
+++ b/core/include/qrsignatures.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
 
 /**
  * signature verification wrapper for trezor crypto util.

--- a/core/include/sign.h
+++ b/core/include/sign.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <squareup/subzero/internal.pb.h>
+
 Result handle_sign_tx(
     const InternalCommandRequest_SignTxRequest* const request,
     InternalCommandResponse_SignTxResponse *response);

--- a/core/src/checks/bip32.c
+++ b/core/src/checks/bip32.c
@@ -1,14 +1,14 @@
-#include <stdio.h>
-#include <string.h>
-
 #include "bip32.h"
-#include "bip39.h"
-#include "curves.h"
 
-#include "config.h"
+#include "bip39.h"
 #include "checks.h"
+#include "config.h"
+#include "curves.h"
 #include "log.h"
 #include "squareup/subzero/internal.pb.h"
+
+#include <stdio.h>
+#include <string.h>
 
 /**
  * Perform BIP32 derivation using a hardcoded mnemonic and verify that we get

--- a/core/src/checks/check_sign_tx.c
+++ b/core/src/checks/check_sign_tx.c
@@ -1,33 +1,30 @@
 #include "base58.h"
 #include "bip32.h"
 #include "bip39.h"
+#include "checks.h"
+#include "conv.h"
 #include "curves.h"
+#include "ecdsa.h"
+#include "hash.h"
+#include "log.h"
+#include "memzero.h"
+#include "nist256p1.h"
+#include "print.h"
+#include "qrsignatures.h"
+#include "script.h"
+#include "sign.h"
+
 #include <assert.h>
 #include <config.h>
+#include <pb_decode.h>
+#include <pb_encode.h>
 #include <protection.h>
 #include <rpc.h>
-#include <pb_encode.h>
-#include <pb_decode.h>
 #include <squareup/subzero/common.pb.h>
 #include <squareup/subzero/internal.pb.h>
 #include <squareup/subzero/service.pb.h>
 #include <stdio.h>
 #include <string.h>
-
-#include <assert.h>
-
-#include "checks.h"
-#include "conv.h"
-#include "hash.h"
-#include "log.h"
-#include "print.h"
-#include "script.h"
-#include "sign.h"
-#include "ecdsa.h"
-#include "nist256p1.h"
-#include "memzero.h"
-#include "qrsignatures.h"
-
 
 // Return a constructed request for test
 static int construct_request(InternalCommandRequest_SignTxRequest *tx) {

--- a/core/src/checks/conv_checks.c
+++ b/core/src/checks/conv_checks.c
@@ -1,9 +1,9 @@
-#include <inttypes.h>
-#include <stdint.h>
-
 #include "checks.h"
 #include "conv.h"
 #include "log.h"
+
+#include <inttypes.h>
+#include <stdint.h>
 
 int verify_conv_btc_to_satoshi(void) {
   uint32_t btc = 0;

--- a/core/src/checks/self_checks.c
+++ b/core/src/checks/self_checks.c
@@ -1,8 +1,8 @@
-#include <stdio.h>
-#include <stdlib.h>
-
 #include "checks.h"
 #include "log.h"
+
+#include <stdio.h>
+#include <stdlib.h>
 
 typedef int (*self_check_function)(void);
 

--- a/core/src/checks/validate_fees.c
+++ b/core/src/checks/validate_fees.c
@@ -1,10 +1,10 @@
-#include <stdio.h>
-
 #include "checks.h"
+#include "log.h"
 #include "rpc.h"
 #include "sign.h"
 #include "squareup/subzero/internal.pb.h"
-#include "log.h"
+
+#include <stdio.h>
 
 int verify_validate_fees(void) {
   int r = 0;

--- a/core/src/dev/aes_gcm.c
+++ b/core/src/dev/aes_gcm.c
@@ -1,10 +1,11 @@
-#include <stdint.h>
-#include <squareup/subzero/internal.pb.h> // For error codes
-#include "log.h"
-#include "memzero.h"
 #include "aes_gcm_dev.h"
 #include "gcm.h"
+#include "log.h"
+#include "memzero.h"
 #include "rand.h"
+
+#include <squareup/subzero/internal.pb.h> // For error codes
+#include <stdint.h>
 
 #define IV_SIZE_IN_BYTES (12)
 #define TAG_SIZE_IN_BYTES (16)

--- a/core/src/dev/execute_command_hooks.c
+++ b/core/src/dev/execute_command_hooks.c
@@ -1,6 +1,6 @@
-#include <squareup/subzero/internal.pb.h>
-
 #include "rpc.h"
+
+#include <squareup/subzero/internal.pb.h>
 
 Result pre_execute_command(const InternalCommandRequest* const in) {
   (void)in;

--- a/core/src/dev/init_wallet.c
+++ b/core/src/dev/init_wallet.c
@@ -1,20 +1,21 @@
-#include <assert.h>
-#include <pb_decode.h>
-#include <pb_encode.h>
-#include <squareup/subzero/common.pb.h>
-#include <squareup/subzero/internal.pb.h>
-#include <stdio.h>
+#include "init_wallet.h"
 
 #include "bip32.h"
 #include "bip39.h"
 #include "checks.h"
 #include "config.h"
 #include "curves.h"
-#include "init_wallet.h"
 #include "log.h"
 #include "protection.h"
 #include "rand.h"
 #include "rpc.h"
+
+#include <assert.h>
+#include <pb_decode.h>
+#include <pb_encode.h>
+#include <squareup/subzero/common.pb.h>
+#include <squareup/subzero/internal.pb.h>
+#include <stdio.h>
 
 /**
  * Initialize a wallet.

--- a/core/src/dev/no_rollback.c
+++ b/core/src/dev/no_rollback.c
@@ -1,11 +1,12 @@
+#include "no_rollback.h"
+
+#include "config.h"
+#include "log.h"
+
 #include <assert.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-
-#include "no_rollback.h"
-#include "config.h"
-#include "log.h"
 
 Result no_rollback_read(const char* filename, char buf[static VERSION_SIZE]) {
   char tmp_file[100];

--- a/core/src/dev/protection.c
+++ b/core/src/dev/protection.c
@@ -1,12 +1,13 @@
-#include <assert.h>
-#include <protection.h>
-#include <squareup/subzero/common.pb.h>
-#include <squareup/subzero/internal.pb.h>
+#include "protection.h"
 
+#include "aes_gcm_dev.h"
 #include "log.h"
 #include "memzero.h"
-#include "aes_gcm_dev.h"
 #include "rand.h"
+
+#include <assert.h>
+#include <squareup/subzero/common.pb.h>
+#include <squareup/subzero/internal.pb.h>
 
 // Protection: developer edition.
 

--- a/core/src/finalize_wallet.c
+++ b/core/src/finalize_wallet.c
@@ -1,13 +1,13 @@
-#include <assert.h>
-#include <bip32.h>
-#include <curves.h>
-#include <squareup/subzero/internal.pb.h>
-
 #include "config.h"
 #include "log.h"
 #include "protection.h"
 #include "rpc.h"
 #include "strlcpy.h"
+
+#include <assert.h>
+#include <bip32.h>
+#include <curves.h>
+#include <squareup/subzero/internal.pb.h>
 
 Result
 handle_finalize_wallet(

--- a/core/src/fuzz.c
+++ b/core/src/fuzz.c
@@ -1,14 +1,14 @@
-#include <stdio.h>
-#include <sys/stat.h>
-#include <stdlib.h>
-#include <string.h>
-#include <fcntl.h>
-#include <errno.h>
-#include <unistd.h>
-
 #include "pb_decode.h"
 #include "pb_encode.h"
 #include "rpc.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 /* This is useful for debugging the fuzz driver. from nanopb docs. */
 static bool fwrite_callback(pb_ostream_t *stream, const uint8_t *buf, size_t count) {

--- a/core/src/init_wallet.c
+++ b/core/src/init_wallet.c
@@ -1,4 +1,5 @@
 #include "init_wallet.h"
+
 #include "log.h"
 
 /**

--- a/core/src/main.c
+++ b/core/src/main.c
@@ -2,15 +2,6 @@
  * nCipher wallet code.
  */
 
-#include <arpa/inet.h>
-#include <netinet/in.h>
-#include <stdio.h>
-#include <string.h>
-#include <sys/socket.h>
-#include <unistd.h>
-#include <stdbool.h>
-
-#include "no_rollback.h"
 #include "checks.h"
 #include "config.h"
 #include "hash.h"
@@ -18,10 +9,19 @@
 #include "log.h"
 #include "memzero.h"
 #include "nanopb_stream.h"
+#include "no_rollback.h"
 #include "pb_decode.h"
 #include "pb_encode.h"
 #include "print.h"
 #include "rpc.h"
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
 
 int main(int argc, char **argv) {
   int r;

--- a/core/src/memzero.c
+++ b/core/src/memzero.c
@@ -1,6 +1,6 @@
-#include <stdint.h>
-
 #include "memzero.h"
+
+#include <stdint.h>
 
 /**
  * This function MUST NEVER be included in a file with any other functions.

--- a/core/src/nanopb_stream.c
+++ b/core/src/nanopb_stream.c
@@ -2,12 +2,12 @@
  * This file is mostly a copy of nanopb/examples/network_server/common.h
  */
 
+#include "nanopb_stream.h"
+
 #include <pb_decode.h>
 #include <pb_encode.h>
 #include <sys/socket.h>
 #include <sys/types.h>
-
-#include "nanopb_stream.h"
 
 static bool write_callback(pb_ostream_t *stream, const uint8_t *buf,
                            size_t count) {

--- a/core/src/ncipher/additional_checks.c
+++ b/core/src/ncipher/additional_checks.c
@@ -1,12 +1,12 @@
-#include <nfastapp.h>
-#include <seelib.h>
-#include <stdint.h>
-#include <squareup/subzero/internal.pb.h> // For error codes
-
 #include "aes_gcm_ncipher.h"
 #include "checks.h"
 #include "log.h"
 #include "transact.h"
+
+#include <nfastapp.h>
+#include <seelib.h>
+#include <squareup/subzero/internal.pb.h> // For error codes
+#include <stdint.h>
 
 extern M_KeyID master_seed_encryption_key;
 extern M_KeyID pub_key_encryption_key;

--- a/core/src/ncipher/aes_gcm.c
+++ b/core/src/ncipher/aes_gcm.c
@@ -1,15 +1,14 @@
-#include <nfastapp.h>
-#include <seelib.h>
-#include <stdint.h>
-#include <string.h>
-#include <strings.h>
-#include <squareup/subzero/internal.pb.h> // For error codes
-
 #include "aes_gcm_ncipher.h"
 #include "log.h"
 #include "memzero.h"
 #include "transact.h"
 
+#include <nfastapp.h>
+#include <seelib.h>
+#include <squareup/subzero/internal.pb.h> // For error codes
+#include <stdint.h>
+#include <string.h>
+#include <strings.h>
 
 #define IV_SIZE_IN_BYTES (12)
 #define TAG_SIZE_IN_BYTES (16)

--- a/core/src/ncipher/execute_command_hooks.c
+++ b/core/src/ncipher/execute_command_hooks.c
@@ -1,13 +1,3 @@
-#include <assert.h>
-#include <examples/network_server/common.h>
-#include <nfastapp.h>
-#include <pb_decode.h>
-#include <pb_encode.h>
-#include <seelib.h>
-#include <squareup/subzero/common.pb.h>
-#include <squareup/subzero/internal.pb.h>
-#include <stdio.h>
-
 #include "bip32.h"
 #include "bip39.h"
 #include "checks.h"
@@ -19,6 +9,16 @@
 #include "rand.h"
 #include "rpc.h"
 #include "transact.h"
+
+#include <assert.h>
+#include <examples/network_server/common.h>
+#include <nfastapp.h>
+#include <pb_decode.h>
+#include <pb_encode.h>
+#include <seelib.h>
+#include <squareup/subzero/common.pb.h>
+#include <squareup/subzero/internal.pb.h>
+#include <stdio.h>
 
 extern NFast_AppHandle app;
 

--- a/core/src/ncipher/init.c
+++ b/core/src/ncipher/init.c
@@ -1,11 +1,11 @@
-#include <nfastapp.h>
-#include <stdbool.h>
-
-#include <squareup/subzero/internal.pb.h>
-
-#include "module_certificate.h"
 #include "init.h"
+
 #include "log.h"
+#include "module_certificate.h"
+
+#include <nfastapp.h>
+#include <squareup/subzero/internal.pb.h>
+#include <stdbool.h>
 
 NFastApp_Connection conn;
 NFast_AppHandle app;

--- a/core/src/ncipher/init_wallet.c
+++ b/core/src/ncipher/init_wallet.c
@@ -1,3 +1,16 @@
+#include "init_wallet.h"
+
+#include "bip32.h"
+#include "bip39.h"
+#include "checks.h"
+#include "config.h"
+#include "curves.h"
+#include "log.h"
+#include "protection.h"
+#include "rand.h"
+#include "rpc.h"
+#include "transact.h"
+
 #include <assert.h>
 #include <examples/network_server/common.h>
 #include <nfastapp.h>
@@ -7,18 +20,6 @@
 #include <squareup/subzero/common.pb.h>
 #include <squareup/subzero/internal.pb.h>
 #include <stdio.h>
-
-#include "bip32.h"
-#include "bip39.h"
-#include "checks.h"
-#include "config.h"
-#include "curves.h"
-#include "init_wallet.h"
-#include "log.h"
-#include "protection.h"
-#include "rand.h"
-#include "rpc.h"
-#include "transact.h"
 
 extern NFast_AppHandle app;
 

--- a/core/src/ncipher/module_certificate.c
+++ b/core/src/ncipher/module_certificate.c
@@ -1,12 +1,13 @@
-#include <nfastapp.h>
-#include <seelib.h>
-#include <string.h>
-#include <stdlib.h>
-
 #include "module_certificate.h"
+
 #include "log.h"
 #include "memzero.h"
 #include "transact.h"
+
+#include <nfastapp.h>
+#include <seelib.h>
+#include <stdlib.h>
+#include <string.h>
 
 extern NFast_AppHandle app;
 

--- a/core/src/ncipher/no_rollback.c
+++ b/core/src/ncipher/no_rollback.c
@@ -1,3 +1,9 @@
+#include "no_rollback.h"
+
+#include "config.h"
+#include "log.h"
+#include "transact.h"
+
 #include <assert.h>
 #include <nfastapp.h>
 #include <seelib.h>
@@ -5,11 +11,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
-#include "no_rollback.h"
-#include "config.h"
-#include "log.h"
-#include "transact.h"
 
 extern NFast_AppHandle app;
 

--- a/core/src/ncipher/protection.c
+++ b/core/src/ncipher/protection.c
@@ -1,13 +1,13 @@
+#include "aes_gcm_ncipher.h"
+#include "config.h"
+#include "log.h"
+
 #include <assert.h>
 #include <nfastapp.h>
 #include <protection.h>
 #include <seelib.h>
 #include <squareup/subzero/common.pb.h>
 #include <squareup/subzero/internal.pb.h>
-
-#include "aes_gcm_ncipher.h"
-#include "config.h"
-#include "log.h"
 
 // Protection: ncipher edition.
 

--- a/core/src/ncipher/transact.c
+++ b/core/src/ncipher/transact.c
@@ -1,7 +1,8 @@
-#include <nfastapp.h>
+#include "transact.h"
 
 #include "log.h"
-#include "transact.h"
+
+#include <nfastapp.h>
 
 /**
  * Sets certs_present and takes care of error handling.

--- a/core/src/no_rollback.c
+++ b/core/src/no_rollback.c
@@ -1,7 +1,9 @@
-#include <stdlib.h> /* strtoul */
-#include <inttypes.h>
 #include "no_rollback.h"
+
 #include "log.h"
+
+#include <inttypes.h>
+#include <stdlib.h> /* strtoul */
 
 /**
  * Prevents running an older version of core after a newer version has been seen. The goal is to limit the attack

--- a/core/src/print.c
+++ b/core/src/print.c
@@ -1,8 +1,9 @@
-#include <stdint.h>
-#include <stdio.h>
+#include "print.h"
 
 #include "log.h"
-#include "print.h"
+
+#include <stdint.h>
+#include <stdio.h>
 
 // TODO: this file and hash.c have a lot of code in common. We should
 // pull the common code in a set of serializer_* functions.

--- a/core/src/qrsignatures.c
+++ b/core/src/qrsignatures.c
@@ -1,15 +1,16 @@
-#include <unistd.h>
-#include <stdbool.h>
-#include <string.h>
-#include <stdio.h>
+#include "qrsignatures.h"
 
-#include "ecdsa.h"
+#include "config.h"
 #include "curves.h"
+#include "ecdsa.h"
+#include "log.h"
 #include "memzero.h"
 #include "nist256p1.h"
-#include "qrsignatures.h"
-#include "log.h"
-#include "config.h"
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
 
 static const uint8_t QR_PUBKEY[65] = _QR_PUBKEY;
 bool check_qrsignature(const uint8_t * const data, size_t data_len, const uint8_t * const signature){

--- a/core/src/rpc.c
+++ b/core/src/rpc.c
@@ -1,16 +1,16 @@
-#include <stdio.h>
+#include "rpc.h"
+
+#include "checks.h"
+#include "config.h"
+#include "log.h"
+#include "qrsignatures.h"
+#include "sign.h"
 
 #include <pb_decode.h>
 #include <pb_encode.h>
 #include <squareup/subzero/internal.pb.h>
 #include <squareup/subzero/service.pb.h>
-
-#include "checks.h"
-#include "config.h"
-#include "log.h"
-#include "rpc.h"
-#include "sign.h"
-#include "qrsignatures.h"
+#include <stdio.h>
 
 static void execute_command(const InternalCommandRequest* const cmd,
                             InternalCommandResponse *out);

--- a/core/src/script.c
+++ b/core/src/script.c
@@ -1,4 +1,5 @@
 #include "script.h"
+
 #include <log.h>
 #include <squareup/subzero/internal.pb.h>
 

--- a/core/src/sign.c
+++ b/core/src/sign.c
@@ -1,3 +1,13 @@
+#include "sign.h"
+
+#include "bip32.h"
+#include "conv.h"
+#include "hash.h"
+#include "log.h"
+#include "memzero.h"
+#include "rpc.h"
+#include "script.h"
+
 #include <assert.h>
 #include <base58.h>
 #include <bip32.h>
@@ -10,15 +20,6 @@
 #include <squareup/subzero/internal.pb.h>
 #include <stdbool.h>
 #include <stdio.h>
-
-#include "bip32.h"
-#include "conv.h"
-#include "hash.h"
-#include "log.h"
-#include "rpc.h"
-#include "script.h"
-#include "sign.h"
-#include "memzero.h"
 
 static void compute_prevout_hash(const TxInput* const inputs,
                                  pb_size_t inputs_count,


### PR DESCRIPTION
Auto-format the include sections of all files using clang-format. Fix the resulting build breaks by adding missing includes. This makes the build less fragile as compilation success doesn't depend as much on include order.

We're not all the way there since this isn't a full "IWYU" (include what you use) pass. But, it's a start.