### PR TITLE
[core] add aes_gcm_common.h with shared constants

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -175,8 +175,7 @@ set(checks_SRC
 list(APPEND main_SRC ${checks_SRC})
 
 set(include_SRC
-    "include/aes_gcm_dev.h"
-    "include/aes_gcm_ncipher.h"
+    "include/aes_gcm_common.h"
     "include/checks.h"
     "include/config.h"
     "include/conv.h"
@@ -198,6 +197,7 @@ list(APPEND main_SRC ${include_SRC})
 
 if ($ENV{TARGET} MATCHES "nCipher")
   set(extra_SRC
+      "include/aes_gcm_ncipher.h"
       "src/ncipher/additional_checks.c"
       "src/ncipher/aes_gcm.c"
       "src/ncipher/execute_command_hooks.c"
@@ -211,6 +211,7 @@ if ($ENV{TARGET} MATCHES "nCipher")
   list(APPEND main_SRC ${extra_SRC})
 else ()
   set(extra_SRC
+      "include/aes_gcm_dev.h"
       "src/dev/additional_checks.c"
       "src/dev/no_rollback.c"
       "src/dev/execute_command_hooks.c"

--- a/core/include/aes_gcm_common.h
+++ b/core/include/aes_gcm_common.h
@@ -1,0 +1,7 @@
+#pragma once
+
+// Common definitions included by both aes_gcm_dev.h and aes_gcm_ncipher.h
+
+#define AES_GCM_IV_SIZE_IN_BYTES (12)
+#define AES_GCM_TAG_SIZE_IN_BYTES (16)
+#define AES_GCM_OVERHEAD_BYTES (AES_GCM_IV_SIZE_IN_BYTES + AES_GCM_TAG_SIZE_IN_BYTES)

--- a/core/src/checks/verify_protect_pubkey.c
+++ b/core/src/checks/verify_protect_pubkey.c
@@ -1,3 +1,4 @@
+#include "aes_gcm_common.h"
 #include "checks.h"
 #include "config.h"
 #include "log.h"
@@ -53,7 +54,7 @@ int verify_protect_pubkey(void) {
   temp.has_encrypted_pub_key = true;
 
   size_t oldsize = temp.encrypted_pub_key.size;
-  temp.encrypted_pub_key.size = XPUB_SIZE + 16 + 12;
+  temp.encrypted_pub_key.size = XPUB_SIZE + AES_GCM_OVERHEAD_BYTES;
   ERROR("(next line is expected to show red text...)");
   r = expose_pubkey(&temp, buffer3);
   if (Result_EXPOSE_PUBKEY_UNEXPECTED_ENCRYPTED_PUBKEY_SIZE_FAILURE != r) {

--- a/core/src/dev/aes_gcm.c
+++ b/core/src/dev/aes_gcm.c
@@ -1,3 +1,4 @@
+#include "aes_gcm_common.h"
 #include "aes_gcm_dev.h"
 #include "gcm.h"
 #include "log.h"
@@ -7,8 +8,8 @@
 #include <squareup/subzero/internal.pb.h> // For error codes
 #include <stdint.h>
 
-#define IV_SIZE_IN_BYTES (12)
-#define TAG_SIZE_IN_BYTES (16)
+#define IV_SIZE_IN_BYTES AES_GCM_IV_SIZE_IN_BYTES
+#define TAG_SIZE_IN_BYTES AES_GCM_TAG_SIZE_IN_BYTES
 
 // Temp buffer for backing up content, etc.
 // Because subzero CORE is supposed to be single-threaded, we use a global

--- a/core/src/protect.c
+++ b/core/src/protect.c
@@ -1,3 +1,8 @@
+#include "aes_gcm_common.h"
+
+#define MAX_ENCRYPTED_PUBKEY_SIZE (XPUB_SIZE + AES_GCM_OVERHEAD_BYTES)
+#define ENCRYPTED_MASTER_SEED_SIZE (MASTER_SEED_SIZE + AES_GCM_OVERHEAD_BYTES)
+
 /**
  * Encrypt xpub with the pubkey encryption key.
  *
@@ -14,8 +19,7 @@ Result protect_pubkey(char xpub[static XPUB_SIZE],
     return Result_UNKNOWN_INTERNAL_FAILURE;
   }
 
-  static_assert(sizeof(encrypted_pub_key->encrypted_pub_key.bytes) >=
-                XPUB_SIZE + 12 + 16,
+  static_assert(sizeof(encrypted_pub_key->encrypted_pub_key.bytes) >= MAX_ENCRYPTED_PUBKEY_SIZE,
                 "misconfigured encrypted_pub_key max size");
   if (pub_key_encryption_key == 0) {
     ERROR("pub_key_encryption_key not initialized");
@@ -68,7 +72,7 @@ Result expose_pubkey(const EncryptedPubKey* const encrypted_pub_key,
     ERROR("missing encrypted_pub_key");
     return Result_EXPOSE_PUBKEY_NO_ENCRYPTED_PUBKEY_FAILURE;
   }
-  if (encrypted_pub_key->encrypted_pub_key.size >= (XPUB_SIZE + 16 + 12)) {
+  if (encrypted_pub_key->encrypted_pub_key.size >= MAX_ENCRYPTED_PUBKEY_SIZE) {
     ERROR("unexpected encrypted_pub_key size");
     return Result_EXPOSE_PUBKEY_UNEXPECTED_ENCRYPTED_PUBKEY_SIZE_FAILURE;
   }
@@ -139,8 +143,7 @@ Result expose_wallet(const EncryptedMasterSeed* const encrypted_master_seed,
     return Result_EXPOSE_WALLET_NO_MASTER_SEED_ENCRYPTION_KEY_FAILURE;
   }
 
-  if (encrypted_master_seed->encrypted_master_seed.size !=
-      MASTER_SEED_SIZE + 16 + 12) {
+  if (encrypted_master_seed->encrypted_master_seed.size != ENCRYPTED_MASTER_SEED_SIZE) {
     ERROR("Unexpected encrypted_master_seed size");
     return Result_EXPOSE_WALLET_UNEXPECTED_ENCRYPTED_MASTER_SEED_SIZE_FAILURE;
   }


### PR DESCRIPTION
This is a follow-up to #573, now that I can properly test the change on HSM hardware.