### PR TITLE
[core] fix possible stack buffer overflow in no_rollback logic

### DIFF
--- a/core/src/dev/no_rollback.c
+++ b/core/src/dev/no_rollback.c
@@ -26,10 +26,19 @@ Result no_rollback_read(const char* filename, char buf[static VERSION_SIZE]) {
     ERROR("%s failed", __func__);
     return Result_NO_ROLLBACK_FILE_NOT_FOUND;
   }
+  if (buf[VERSION_SIZE - 1] != '\0') {
+    ERROR("%s: rollback file contents not NULL-terminated", __func__);
+    return Result_NO_ROLLBACK_INVALID_FORMAT;
+  }
   return Result_SUCCESS;
 }
 
 Result no_rollback_write(const char* filename, char buf[static VERSION_SIZE]) {
+  if (buf[VERSION_SIZE - 1] != '\0') {
+    ERROR("%s: input buf is not NULL-terminated", __func__);
+    return Result_NO_ROLLBACK_INVALID_FORMAT;
+  }
+
   char tmp_file[100];
   snprintf(tmp_file, sizeof(tmp_file), "/tmp/%s", filename);
 

--- a/core/src/ncipher/no_rollback.c
+++ b/core/src/ncipher/no_rollback.c
@@ -62,12 +62,23 @@ Result no_rollback_read(const char* filename, char buf[static VERSION_SIZE]) {
     return Result_UNKNOWN_INTERNAL_FAILURE;
   }
 
+  if (reply.reply.nvmemop.res.read.data.ptr[VERSION_SIZE - 1] != '\0') {
+    ERROR("%s: rollback NVRAM contents not NULL-terminated", __func__);
+    NFastApp_Free_Reply(app, NULL, NULL, &reply);
+    return Result_NO_ROLLBACK_INVALID_FORMAT;
+  }
+
   memcpy(buf, reply.reply.nvmemop.res.read.data.ptr, VERSION_SIZE);
   NFastApp_Free_Reply(app, NULL, NULL, &reply);
   return Result_SUCCESS;
 }
 
 Result no_rollback_write(const char* filename, char buf[static VERSION_SIZE]) {
+  if (buf[VERSION_SIZE - 1] != '\0') {
+    ERROR("%s: input buf is not NULL-terminated", __func__);
+    return Result_NO_ROLLBACK_INVALID_FORMAT;
+  }
+
   Result r = Result_UNKNOWN_INTERNAL_FAILURE;
 
   M_Command command = {0};


### PR DESCRIPTION
The parsing logic in no_rollback_check() could end up reading past the end of the stack buffer if the file contains a string with lots of leading 0s, followed by the expected magic number, followed by a dash ('-').

Since the VERSION_SIZE is 100 but we only store 2 uint32's and a dash, we always use much less than 100 bytes. So it's safe to assume that the rest of the buffer will contain NULL characters.

This change enforces this assumption on both reads and writes of the no_rollback file (dev mode) / NVRAM (ncipher mode).

I tried adding a self-check which fails ASAN with the bad input, but apparently the strtoul() function is not ASAN-instrumented (at least on MacOS). So, I couldn't actually get ASAN to crash with an out-of-bounds read, though I was able to get ASAN crashes by replacing the strtoul() with my own parsing function. Sigh.