### PR TITLE
[core] implement missing logic in script.c to handle longer data

### DIFF
--- a/core/include/checks.h
+++ b/core/include/checks.h
@@ -35,6 +35,14 @@ int post_run_self_checks(void);
  */
 int verify_byte_order(void);
 
+/**
+ * Makes sure that the *_to_little_endian_bytes() functions are implemented correctly.
+ * These are used by script.c and getting them wrong would result in corrupted bitcoin scripts
+ * which would get rejected by the network.
+ */
+int verify_u16_to_little_endian_bytes(void);
+int verify_u32_to_little_endian_bytes(void);
+
 int verify_bip32(void);
 int verify_sign_tx(void);
 int verify_validate_fees(void);

--- a/core/include/conv.h
+++ b/core/include/conv.h
@@ -1,5 +1,31 @@
 #pragma once
 
+#include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
+/**
+ * Converts the given amount in BTC to the equivalent amount in Satoshis.
+ * This just multiplies by 100 million, since 1 BTC == 100,000,000 Satoshis.
+ */
 uint64_t conv_btc_to_satoshi(uint32_t btc);
+
+/**
+ * Writes the given 16-bit unsigned integer to the given buffer in little endian byte order.
+ * Preconditions:
+ * - buf_len must equal sizeof(uint16_t)
+ * - buf must not be NULL.
+ *
+ * Returns true on success or false if any of the preconditions were not met.
+ */
+bool u16_to_little_endian_bytes(const uint16_t value, uint8_t* const buf, const size_t buf_len);
+
+/**
+ * Writes the given 32-bit unsigned integer to the given buffer in little endian byte order.
+ * Preconditions:
+ * - buf_len must equal sizeof(uint32_t)
+ * - buf must not be NULL.
+ *
+ * Returns true on success or false if any of the preconditions were not met.
+ */
+bool u32_to_little_endian_bytes(const uint32_t value, uint8_t* const buf, const size_t buf_len);

--- a/core/include/script.h
+++ b/core/include/script.h
@@ -161,5 +161,5 @@ enum opcodetype {
   OP_INVALIDOPCODE = 0xff,
 };
 
-Result script_push(script_t *script, enum opcodetype opcode);
+Result script_push(script_t *script, uint8_t byte);
 Result script_push_data(script_t *script, const uint8_t *data, size_t len);

--- a/core/src/checks/conv_checks.c
+++ b/core/src/checks/conv_checks.c
@@ -45,3 +45,69 @@ int verify_conv_btc_to_satoshi(void) {
   INFO("verify_conv_btc_to_satoshi: ok");
   return 0;
 }
+
+int verify_u16_to_little_endian_bytes(void) {
+  uint8_t buf[sizeof(uint16_t)] = { 0 };
+  const uint16_t value = (uint16_t) 0x0102;
+
+  // positive test
+  if (!u16_to_little_endian_bytes(value, buf, sizeof(buf))) {
+    ERROR("%s: u16_to_little_endian_bytes() failed", __func__);
+    return -1;
+  }
+  if (buf[0] != 2 || buf[1] != 1) {
+    ERROR("%s: u16_to_little_endian_bytes() wrote incorrect buf: 0x%hhx%hhx", __func__, buf[0], buf[1]);
+    return -1;
+  }
+
+  // negative tests
+  ERROR("(next line is expected to show red text...)");
+  if (u16_to_little_endian_bytes(value, buf, sizeof(buf) - 1)) {
+    ERROR("%s: u16_to_little_endian_bytes() should have rejected wrong-size buf but didn't", __func__);
+    return -1;
+  }
+  ERROR("(next line is expected to show red text...)");
+  if (u16_to_little_endian_bytes(value, NULL, sizeof(buf))) {
+    ERROR("%s: u16_to_little_endian_bytes() should have rejected NULL buf but didn't", __func__);
+    return -1;
+  }
+
+  INFO("%s: ok", __func__);
+  return 0;
+}
+
+int verify_u32_to_little_endian_bytes(void) {
+  uint8_t buf[sizeof(uint32_t)] = { 0 };
+  const uint32_t value = (uint32_t) 0x01020304;
+
+  // positive test
+  if (!u32_to_little_endian_bytes(value, buf, sizeof(buf))) {
+    ERROR("%s: u32_to_little_endian_bytes() failed", __func__);
+    return -1;
+  }
+  if (buf[0] != 4 || buf[1] != 3 || buf[2] != 2 || buf[3] != 1) {
+    ERROR(
+        "%s: u32_to_little_endian_bytes() wrote incorrect buf: 0x%hhx%hhx%hhx%hhx",
+        __func__,
+        buf[0],
+        buf[1],
+        buf[2],
+        buf[3]);
+    return -1;
+  }
+
+  // negative tests
+  ERROR("(next line is expected to show red text...)");
+  if (u32_to_little_endian_bytes(value, buf, sizeof(buf) - 1)) {
+    ERROR("%s: u32_to_little_endian_bytes() should have rejected wrong-size buf but didn't", __func__);
+    return -1;
+  }
+  ERROR("(next line is expected to show red text...)");
+  if (u32_to_little_endian_bytes(value, NULL, sizeof(buf))) {
+    ERROR("%s: u32_to_little_endian_bytes() should have rejected NULL buf but didn't", __func__);
+    return -1;
+  }
+
+  INFO("%s: ok", __func__);
+  return 0;
+}

--- a/core/src/checks/self_checks.c
+++ b/core/src/checks/self_checks.c
@@ -31,7 +31,7 @@ static void register_self_check(self_check_function func, const char* name) {
 }
 
 // For each new self check function added, this constant needs to be incremented by 1.
-#define EXPECTED_SELF_CHECKS_COUNT ((size_t) 10)
+#define EXPECTED_SELF_CHECKS_COUNT ((size_t) 12)
 
 #define REGISTER_SELF_CHECK(name) register_self_check(name, #name)
 
@@ -44,6 +44,8 @@ static void register_all_self_checks(void) {
   }
 
   REGISTER_SELF_CHECK(verify_byte_order);
+  REGISTER_SELF_CHECK(verify_u16_to_little_endian_bytes);
+  REGISTER_SELF_CHECK(verify_u32_to_little_endian_bytes);
   REGISTER_SELF_CHECK(verify_mix_entropy);
   REGISTER_SELF_CHECK(verify_protect_pubkey);
   REGISTER_SELF_CHECK(verify_bip32);

--- a/core/src/conv.c
+++ b/core/src/conv.c
@@ -1,5 +1,41 @@
 #include "conv.h"
 
+#include "log.h"
+
+#include <assert.h>
+
 uint64_t conv_btc_to_satoshi(uint32_t btc) {
-    return (uint64_t) btc * 100000000ull;
+  return (uint64_t) btc * 100000000ull;
+}
+
+bool u16_to_little_endian_bytes(const uint16_t value, uint8_t* const buf, const size_t buf_len) {
+  static_assert(sizeof(uint16_t) == 2, "sizeof(uint16_t) != 2");
+  if (sizeof(uint16_t) != buf_len) {
+    ERROR("%s: buf_len == %zu, expected: %zu", __func__, buf_len, sizeof(uint16_t));
+    return false;
+  }
+  if (NULL == buf) {
+    ERROR("%s: input buf is NULL", __func__);
+    return false;
+  }
+  buf[0] = (uint8_t) (value & 0xFF);
+  buf[1] = (uint8_t) ((value >> 8) & 0xFF);
+  return true;
+}
+
+bool u32_to_little_endian_bytes(const uint32_t value, uint8_t* const buf, const size_t buf_len) {
+  static_assert(sizeof(uint32_t) == 4, "sizeof(uint32_t) != 4");
+  if (sizeof(uint32_t) != buf_len) {
+    ERROR("%s: buf_len == %zu, expected: %zu", __func__, buf_len, sizeof(uint32_t));
+    return false;
+  }
+  if (NULL == buf) {
+    ERROR("%s: input buf is NULL", __func__);
+    return false;
+  }
+  buf[0] = (uint8_t) (value & 0xFF);
+  buf[1] = (uint8_t) ((value >> 8) & 0xFF);
+  buf[2] = (uint8_t) ((value >> 16) & 0xFF);
+  buf[3] = (uint8_t) ((value >> 24) & 0xFF);
+  return true;
 }


### PR DESCRIPTION
This required implementing the conversions to little-endian byte order for the multi-byte length fields. These are implemented as standalone functions in conv.c, with new self-checks added for them.

Tested in dev mode on MacOS arm64 (little-endian) and in nCipher mode on nCipher HSM (big-endian).