### PR TITLE
[core] fix subtle conversion bugs in no_rollback logic + improve self checks

### DIFF
--- a/core/include/checks.h
+++ b/core/include/checks.h
@@ -41,6 +41,7 @@ int verify_validate_fees(void);
 int verify_mix_entropy(void);
 int verify_protect_pubkey(void);
 int verify_no_rollback(void);
+int verify_no_rollback_write_to_buf(void);
 int verify_check_qrsignature_pub(void);
 int verify_conv_btc_to_satoshi(void);
 

--- a/core/include/config.h
+++ b/core/include/config.h
@@ -106,6 +106,7 @@
 #define VERSION_MAGIC 0x20de
 
 // VERSION of this code. Must match the value in java/shared/src/main/java/com/squareup/subzero/shared/Constants.java
+// Note that when the version changes, the hard-coded test case in verify_no_rollback_write_to_buf() must be updated.
 #define VERSION 210
 
 // size of the VERSION file / nvram.

--- a/core/include/no_rollback.h
+++ b/core/include/no_rollback.h
@@ -12,3 +12,9 @@ Result no_rollback_write_version(const char* filename, uint32_t magic, uint32_t 
 
 Result no_rollback_read(const char* filename, char buf[static VERSION_SIZE]);
 Result no_rollback_write(const char* filename, char buf[static VERSION_SIZE]);
+
+/**
+ * Writes the given magic and version numbers to the given buffer as strings, with a dash separator.
+ * Fills the rest of the buffer with zero bytes.
+ */
+void no_rollback_write_to_buf(const uint32_t magic, const uint32_t version, char buf[static VERSION_SIZE]);

--- a/core/src/checks/self_checks.c
+++ b/core/src/checks/self_checks.c
@@ -32,7 +32,7 @@ static void register_self_check(self_check_function func, const char* name) {
 }
 
 // For each new self check function added, this constant needs to be incremented by 1.
-#define EXPECTED_SELF_CHECKS_COUNT ((size_t) 10)
+#define EXPECTED_SELF_CHECKS_COUNT ((size_t) 11)
 
 #define REGISTER_SELF_CHECK(name) register_self_check(name, #name)
 
@@ -52,6 +52,7 @@ static void register_all_self_checks(void) {
   REGISTER_SELF_CHECK(verify_check_qrsignature_pub);
   REGISTER_SELF_CHECK(verify_validate_fees);
   REGISTER_SELF_CHECK(verify_no_rollback);
+  REGISTER_SELF_CHECK(verify_no_rollback_write_to_buf);
   REGISTER_SELF_CHECK(verify_conv_btc_to_satoshi);
   REGISTER_SELF_CHECK(verify_rpc_oversized_message_rejected);
 

--- a/core/src/checks/verify_no_rollback.c
+++ b/core/src/checks/verify_no_rollback.c
@@ -71,3 +71,26 @@ int verify_no_rollback(void) {
   INFO("verify_no_rollback: ok");
   return 0;
 }
+
+/**
+ * This hard-coded test case verifies that no_rollback_write_to_buf() produces a known output from the current
+ * VERSION_MAGIC and VERSION constants. It needs to be updated when the VERSION is incremented.
+ */
+int verify_no_rollback_write_to_buf(void) {
+  char buf[VERSION_SIZE];
+  char expected_buf[VERSION_SIZE] = { 0 };
+  static_assert(sizeof(buf) == sizeof(expected_buf), "buf and expected_buf should have the same size");
+
+  no_rollback_write_to_buf(VERSION_MAGIC, VERSION, buf);
+
+  // Note: the VERSION string is at the end. Update it when updating the VERSION constant.
+  const char* expected_string = "8414-210";
+  memcpy(expected_buf, expected_string, strlen(expected_string));
+
+  int res = memcmp(buf, expected_buf, sizeof(buf));
+  if (0 != res) {
+    ERROR("%s: buffers were not equal: buf == %s, expected_buf == %s", __func__, buf, expected_buf);
+  }
+  INFO("%s: ok", __func__);
+  return res;
+}

--- a/core/src/checks/verify_no_rollback.c
+++ b/core/src/checks/verify_no_rollback.c
@@ -1,59 +1,68 @@
 #include "checks.h"
+#include "config.h"
 #include "log.h"
 #include "no_rollback.h"
 #include "squareup/subzero/internal.pb.h"
 
+#include <assert.h>
 #include <stdbool.h>
 
 int verify_no_rollback(void) {
-  char verify_file[] = "selfcheck01";
+  static_assert(VERSION > 0, "Version must not be 0");
+  const uint32_t PREV_VERSION = VERSION - 1;
+  const uint32_t NEXT_VERSION = VERSION + 1;
+
+  // Use a different no_rollback magic constant for tests.
+  const uint32_t TEST_VERSION_MAGIC = VERSION_MAGIC + 1;
+
+  const char verify_file[] = "selfcheck01";
   Result r;
-  r = no_rollback_write_version(verify_file, 1, 1);
+  r = no_rollback_write_version(verify_file, TEST_VERSION_MAGIC, VERSION);
   if (r != Result_SUCCESS) {
     ERROR("verify_no_rollback: no_rollback_write_version failed: %d", r);
     return -1;
   }
 
   ERROR("(next line is expected to show red text...)");
-  r = no_rollback_check(verify_file, true, 0, 1); // should fail with incorrect magic
+  r = no_rollback_check(verify_file, true, VERSION_MAGIC, VERSION); // should fail with incorrect magic
   if (r != Result_NO_ROLLBACK_INVALID_MAGIC) {
     ERROR("verify_no_rollback: expecting incorrect magic, got %d", r);
     return -1;
   }
 
   ERROR("(next line is expected to show red text...)");
-  r = no_rollback_check(verify_file, true, 1, 0); // should fail with rollback detected
+  r = no_rollback_check(verify_file, true, TEST_VERSION_MAGIC, PREV_VERSION); // should fail with rollback detected
   if (r != Result_NO_ROLLBACK_INVALID_VERSION) {
     ERROR("verify_no_rollback: expecting incorrect version (1), got %d", r);
     return -1;
   }
 
-  r = no_rollback_check(verify_file, true, 1, 1); // should succeed
+  r = no_rollback_check(verify_file, true, TEST_VERSION_MAGIC, VERSION); // should succeed
   if (r != Result_SUCCESS) {
     ERROR("verify_no_rollback: expecting success (1), got: %d", r);
     return -1;
   }
 
-  r = no_rollback_check(verify_file, true, 1, 1); // should succeed
+  r = no_rollback_check(verify_file, true, TEST_VERSION_MAGIC, VERSION); // should succeed
   if (r != Result_SUCCESS) {
     ERROR("verify_no_rollback: expecting success (2), got: %d", r);
     return -1;
   }
 
-  r = no_rollback_check(verify_file, true, 1, 2); // should succeed
+  r = no_rollback_check(verify_file, true, TEST_VERSION_MAGIC, NEXT_VERSION); // should succeed
   if (r != Result_SUCCESS) {
     ERROR("verify_no_rollback: expecting success (3), got: %d", r);
     return -1;
   }
 
-  r = no_rollback_check(verify_file, true, 1, 2); // should succeed
+  r = no_rollback_check(verify_file, true, TEST_VERSION_MAGIC, NEXT_VERSION); // should succeed
   if (r != Result_SUCCESS) {
     ERROR("verify_no_rollback: expecting success (4), got: %d", r);
     return -1;
   }
 
   ERROR("(next line is expected to show red text...)");
-  r = no_rollback_check(verify_file, true, 1, 1); // should fail with rollback detected
+  r = no_rollback_check(verify_file, true, TEST_VERSION_MAGIC, VERSION); // should fail with rollback detected
   if (r != Result_NO_ROLLBACK_INVALID_VERSION) {
     ERROR("verify_no_rollback: expecting incorrect version (2), got %d", r);
     return -1;

--- a/core/src/no_rollback.c
+++ b/core/src/no_rollback.c
@@ -34,6 +34,10 @@ Result no_rollback_check(const char* filename, bool allow_upgrade, uint32_t expe
     return r;
   }
 
+  // Note: there's a subtle bug here, because 'unsigned long' and 'uint32_t' may or may not be different types.
+  // But the C standard library doesn't seem to provide a version of strtoul() which parses into a fixed-width type,
+  // and sscanf() has undefined behavior if the value being parsed overflows, so it's pretty tricky to write this
+  // code in a correct and portable way while using standard library functions. Sigh.
   unsigned long magic = 0; // 0 is not a valid magic number
   unsigned long version = 0; // 0 is not a valid version number
   int matches = 0;
@@ -91,6 +95,8 @@ Result no_rollback_write_version(const char* filename, uint32_t magic, uint32_t 
 
   char buf[VERSION_SIZE];
   memset(buf, 0, VERSION_SIZE);
+  // Note: there's a subtle bug here, "%d" is signed int, not uint32_t. It happens to work
+  // with the values we use in practice, for now.
   snprintf(buf, sizeof(buf), "%d-%d", magic, version);
   return no_rollback_write(filename, buf);
 }

--- a/core/src/no_rollback.c
+++ b/core/src/no_rollback.c
@@ -94,9 +94,13 @@ Result no_rollback_write_version(const char* filename, uint32_t magic, uint32_t 
   DEBUG("in no_rollback_write");
 
   char buf[VERSION_SIZE];
+  no_rollback_write_to_buf(magic, version, buf);
+  return no_rollback_write(filename, buf);
+}
+
+void no_rollback_write_to_buf(const uint32_t magic, const uint32_t version, char buf[static VERSION_SIZE]) {
   memset(buf, 0, VERSION_SIZE);
   // Note: there's a subtle bug here, "%d" is signed int, not uint32_t. It happens to work
   // with the values we use in practice, for now.
-  snprintf(buf, sizeof(buf), "%d-%d", magic, version);
-  return no_rollback_write(filename, buf);
+  snprintf(buf, VERSION_SIZE, "%d-%d", magic, version);
 }


### PR DESCRIPTION
1. Use the current VERSION constant in verify_no_rollback
2. Use a more realistic VERSION_MAGIC constant in verify_no_rollback
3. Add a new self check for verifying backward compatibility of no_rollback buffer creation
4. Fix 2 subtle conversion bugs in no_rollback logic