### PR TITLE
[core] standardize and simplify ok messages for passed self checks

### DIFF
--- a/core/src/checks/bip32.c
+++ b/core/src/checks/bip32.c
@@ -89,7 +89,5 @@ int verify_bip32(void) {
   }
   ASSERT_STR_EQUAL(str, BIP32_TEST_CHILD_PUBKEY, "unexpected child public key.");
 
-  INFO("verify_bip32 ok");
-
   return 0;
 }

--- a/core/src/checks/check_sign_tx.c
+++ b/core/src/checks/check_sign_tx.c
@@ -125,9 +125,9 @@ int verify_sign_tx(void) {
     return -1;
   }
   
-  INFO("sign_tx passed");
   return 0;
 }
+
 /**
  * This function does not make an effort to zeroize
  * anything as all of the values are test values.
@@ -259,7 +259,5 @@ int verify_check_qrsignature_pub(void){
     return 12;
   }
 
-  INFO("check_qrsignature_pub passed.");
-  return 0; 
-
+  return 0;
 }

--- a/core/src/checks/conv_checks.c
+++ b/core/src/checks/conv_checks.c
@@ -41,6 +41,5 @@ int verify_conv_btc_to_satoshi(void) {
     return -1;
   }
 
-  INFO("verify_conv_btc_to_satoshi: ok");
   return 0;
 }

--- a/core/src/checks/misc_checks.c
+++ b/core/src/checks/misc_checks.c
@@ -23,6 +23,5 @@ int verify_byte_order(void) {
     return -1;
   }
 #endif
-  INFO("%s: ok", __func__);
   return 0;
 }

--- a/core/src/checks/rpc_checks.c
+++ b/core/src/checks/rpc_checks.c
@@ -275,8 +275,5 @@ out:
   memzero(request_buffer, sizeof(request_buffer));
   memzero(response_buffer, sizeof(response_buffer));
 
-  if (result == 0) {
-    INFO("%s: ok", __func__);
-  }
   return result;
 }

--- a/core/src/checks/self_checks.c
+++ b/core/src/checks/self_checks.c
@@ -94,6 +94,8 @@ int run_self_checks(void) {
     if (t != 0) {
       r = -1;
       ERROR("self check failure: %s failed. rc = %d", self_checks[i].name, t);
+    } else {
+      INFO("%s: ok", self_checks[i].name);
     }
   }
 

--- a/core/src/checks/validate_fees.c
+++ b/core/src/checks/validate_fees.c
@@ -123,9 +123,5 @@ int verify_validate_fees(void) {
            "negative.");
   }
 
-  if (r == 0) {
-    INFO("verify_validate_fees: ok");
-  }
-
   return r;
 }

--- a/core/src/checks/verify_mix_entropy.c
+++ b/core/src/checks/verify_mix_entropy.c
@@ -57,6 +57,5 @@ int verify_mix_entropy(void) {
     return -1;
   }
 
-  INFO("verify_mix_entropy: ok");
   return 0;
 }

--- a/core/src/checks/verify_no_rollback.c
+++ b/core/src/checks/verify_no_rollback.c
@@ -59,6 +59,5 @@ int verify_no_rollback(void) {
     return -1;
   }
 
-  INFO("verify_no_rollback: ok");
   return 0;
 }

--- a/core/src/checks/verify_protect_pubkey.c
+++ b/core/src/checks/verify_protect_pubkey.c
@@ -88,6 +88,5 @@ int verify_protect_pubkey(void) {
     return -1;
   }
 
-  INFO("verify_protect_pubkey: ok");
   return 0;
 }


### PR DESCRIPTION
This change moves the "ok" message for each self check from the self check body into the run_self_checks() function. This simplifies the code and makes the successful messages consistent, which is already the case for failure messages.