### PR TITLE
[core][easy] remove duplicate ok message from self check

### DIFF
--- a/core/src/checks/verify_no_rollback.c
+++ b/core/src/checks/verify_no_rollback.c
@@ -90,6 +90,5 @@ int verify_no_rollback_write_to_buf(void) {
   if (0 != res) {
     ERROR("%s: buffers were not equal: buf == %s, expected_buf == %s", __func__, buf, expected_buf);
   }
-  INFO("%s: ok", __func__);
   return res;
 }


### PR DESCRIPTION
Since #626 and #625 merged right after each other, we ended up with a duplicate "ok" message from verify_no_rollback_write_to_buf().

This commit deduplicates the ok message.