### PR TITLE
Update CodeQL github action to V2

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -51,7 +51,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -62,7 +62,7 @@ jobs:
     # Use Autobuild for languages other than C/C++
     - if: ${{ matrix.language != 'cpp' }}
       name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # Use custom build process for C/C++
     - if: ${{ matrix.language == 'cpp' }}
@@ -70,4 +70,4 @@ jobs:
       run: scripts/build_core.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
See https://github.blog/changelog/2023-01-18-code-scanning-codeql-action-v1-is-now-deprecated/