### PR TITLE
[live-usb-creator] manually package CMake 3.26.4 in dev flavor of live DVD

### DIFF
--- a/live-usb-creator/.gitignore
+++ b/live-usb-creator/.gitignore
@@ -8,3 +8,4 @@ six-1.15.0-py2.py3-none-any.whl
 protobuf-3.14.0-cp36-cp36m-manylinux1_x86_64.whl
 Pillow-8.3.2-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl
 openjdk-19.0.2_linux-x64_bin.tar.gz
+cmake-3.26.4-linux-x86_64.tar.gz

--- a/live-usb-creator/README.md
+++ b/live-usb-creator/README.md
@@ -18,6 +18,7 @@ Set the following files in place in the same directory as the `Vagrantfile`.
 * protobuf-3.14.0-cp36-cp36m-manylinux1_x86_64.whl (1MB): `curl -O -L https://files.pythonhosted.org/packages/fe/fd/247ef25f5ec5f9acecfbc98ca3c6aaf66716cf52509aca9a93583d410493/protobuf-3.14.0-cp36-cp36m-manylinux1_x86_64.whl`
 * Pillow-8.3.2-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl (3.0 MB): `curl -O -L  https://files.pythonhosted.org/packages/6f/2b/7c242e58b1b332a123b4a7bf358e2cc7fa7d904b3576b87defc9528e2bfd/Pillow-8.3.2-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl`
 * openjdk-19.0.2_linux-x64_bin.tar.gz: `curl -O -L https://download.java.net/java/GA/jdk19.0.2/fdb695a9d9064ad6b064dc6df578380c/7/GPL/openjdk-19.0.2_linux-x64_bin.tar.gz`
+* cmake-3.26.4-linux-x86_64.tar.gz: `curl -O -L https://github.com/Kitware/CMake/releases/download/v3.26.4/cmake-3.26.4-linux-x86_64.tar.gz`
 
 Verify the shasums programmatically(checksum file is the output of the manual command below):
 
@@ -42,6 +43,7 @@ a2900100ef9cda17d9c0bbf6a3c3592e809f9842f2d9f0d50e3fba7f3fc864f0  protoc-3.14.0-
 ecc33531a213eee22ad60e0e2aaea6c8ba0021f0cce35dbf0ab03dee6e2a23a1  protobuf-3.14.0-cp36-cp36m-manylinux1_x86_64.whl
 8f284dc1695caf71a74f24993b7c7473d77bc760be45f776a2c2f4e04c170550  Pillow-8.3.2-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl
 34cf8d095cc071e9e10165f5c45023f96ec68397fdaabf6c64bfec1ffeee6198  openjdk-19.0.2_linux-x64_bin.tar.gz
+ba1e0dcc710e2f92be6263f9617510b3660fa9dc409ad2fb8190299563f952a0  cmake-3.26.4-linux-x86_64.tar.gz
 ```
 
 The CentOS's GPG signature can also be verified to confirm the image has been signed by the CentOS team.

--- a/live-usb-creator/checksum
+++ b/live-usb-creator/checksum
@@ -7,3 +7,4 @@ a2900100ef9cda17d9c0bbf6a3c3592e809f9842f2d9f0d50e3fba7f3fc864f0  protoc-3.14.0-
 ecc33531a213eee22ad60e0e2aaea6c8ba0021f0cce35dbf0ab03dee6e2a23a1  protobuf-3.14.0-cp36-cp36m-manylinux1_x86_64.whl
 8f284dc1695caf71a74f24993b7c7473d77bc760be45f776a2c2f4e04c170550  Pillow-8.3.2-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl
 34cf8d095cc071e9e10165f5c45023f96ec68397fdaabf6c64bfec1ffeee6198  openjdk-19.0.2_linux-x64_bin.tar.gz
+ba1e0dcc710e2f92be6263f9617510b3660fa9dc409ad2fb8190299563f952a0  cmake-3.26.4-linux-x86_64.tar.gz

--- a/live-usb-creator/install_scripts/0_post_install_nochroot
+++ b/live-usb-creator/install_scripts/0_post_install_nochroot
@@ -70,4 +70,6 @@ if [ -f "/vagrant/live_scripts/.isotype_dev" ]; then
   cp /vagrant/Pillow-8.3.2-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl /mnt/sysimage/data/app/subzero
   # copy OpenJDK 19.0.2, needed to run the gradle wrapper which builds the Java GUI
   cp /vagrant/openjdk-19.0.2_linux-x64_bin.tar.gz /mnt/sysimage/data/
+  # Copy CMake 3.26.4, the version in CentOS 7 is very old
+  cp /vagrant/cmake-3.26.4-linux-x86_64.tar.gz /mnt/sysimage/data/
 fi

--- a/live-usb-creator/install_scripts/1_post_install_chroot
+++ b/live-usb-creator/install_scripts/1_post_install_chroot
@@ -58,5 +58,12 @@ if [ -f "/usr/local/bin/.isotype_dev" ]; then
   echo 'export JAVA_HOME=/root/jdk-19.0.2' >> /root/.bash_profile
   echo 'export PATH=/root/jdk-19.0.2/bin:$PATH' >> /root/.bash_profile
   rm /data/openjdk-19.0.2_linux-x64_bin.tar.gz
+
+  # Install CMake 3.26.4, needed to build subzero/core with up-to-date nanopb.
+  echo "install CMake 3.26.4"
+  cd /root
+  tar zxf /data/cmake-3.26.4-linux-x86_64.tar.gz
+  echo 'export PATH=/root/cmake-3.26.4-linux-x86_64/bin:$PATH' >> /root/.bash_profile
+  rm /data/cmake-3.26.4-linux-x86_64.tar.gz
 fi
 

--- a/live-usb-creator/rhel7-livemedia-dev.ks
+++ b/live-usb-creator/rhel7-livemedia-dev.ks
@@ -359,7 +359,6 @@ binutils
 git
 autoconf
 automake
-cmake
 libtool
 make
 vim


### PR DESCRIPTION
Since we're planning to update nanopb to 0.4.7 (see #577), we will need a newer version of CMake in order to build subzero/core from the dev flavor of the live DVD. This PR does that.