### PR TITLE
[live-usb-creator] no need for a full JDK in the release image

### DIFF
--- a/live-usb-creator/rhel7-livemedia.ks
+++ b/live-usb-creator/rhel7-livemedia.ks
@@ -347,9 +347,8 @@ syslinux
 grub2-efi-*-cdboot
 grub2-efi-ia32
 
-# Java 8
+# Java 8 Runtime - no need for a full JDK in the release image
 java-1.8.0-openjdk
-java-1.8.0-openjdk-devel
 
 # nCipher stuff
 gcc


### PR DESCRIPTION
The release live DVD/USB doesn't need a JDK since it's not used to build java code. It only needs a JRE to run the gui jar.

Tested by building a release image and booting my at-home HSM machine from it, verified that the GUI still works.