### PR TITLE
[java] add target directory back to .gitignore

### DIFF
--- a/java/.gitignore
+++ b/java/.gitignore
@@ -21,3 +21,6 @@ gradle-app.setting
 .project
 # JDT-specific (Eclipse Java Development Tools)
 .classpath
+
+# Maven output directory. For some reason our gradle build still puts a few things there.
+**/target/


### PR DESCRIPTION
target is the maven output directory, but our new gradle build still puts some .class files there for some reason. Might be a plugin. In any case, add target back to gitignore for now.