### PR TITLE
[core] rewrite fuzzing logic

### DIFF
--- a/core/.gitignore
+++ b/core/.gitignore
@@ -5,3 +5,4 @@
 cmake-build-*
 build/**
 venv/**
+fuzzing_corpus

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -11,6 +11,7 @@ option(ENABLE_ASAN "Enable Address Sanitizer" OFF) # enable with -DENABLE_ASAN=O
 option(ENABLE_MSAN "Enable Uninitialized Memory Sanitizer" OFF) # enable with -DENABLE_MSAN=ON
 option(ENABLE_UBSAN "Enable Undefined Behavior Sanitizer" OFF) # enable with -DENABLE_UBSAN=ON
 option(ENABLE_COVERAGE "Enable code coverage" OFF) # enable with -DENABLE_COVERAGE=ON
+option(ENABLE_FUZZER "Enable fuzzer via LLVM's libfuzzer" OFF) # enable with -DENABLE_FUZZER=ON
 
 if ($ENV{TARGET} MATCHES "nCipher")
   message("Building for nCipher(powerpc32) architecture.")
@@ -21,7 +22,7 @@ if ($ENV{TARGET} MATCHES "nCipher")
   endif ()
 elseif($ENV{TARGET} MATCHES "dev")
   message("Building for the host architecture")
-else()
+else ()
   message(FATAL_ERROR "Unsupported TARGET value.")
 endif ()
 
@@ -53,8 +54,33 @@ if (ENABLE_UBSAN)
   list(APPEND FSANITIZE "undefined")
   list(APPEND EXTRA_SANITIZER_FLAGS "-fno-sanitize-recover=undefined")
 endif ()
- 
-if (ENABLE_ASAN OR ENABLE_MSAN OR ENABLE_UBSAN)
+
+if (ENABLE_FUZZER)
+  # Note that Apple does NOT ship a full Clang toolchain on MacOS (tested on 13.4.1)!
+  # In order to get libfuzzer to link properly, you need to install the full LLVM toolchain
+  # with homebrew, then switch your environment to use the homebrew versions of clang for
+  # building and re-run cmake. It's not recommended to do this globally, as using a 3rd party
+  # clang for everything can break your system, so just do it in a single shell - consider
+  # writing a script which does this.
+  # On my machine this looks like:
+  #   export PATH="/opt/homebrew/opt/llvm/bin:$PATH"
+  #   export LDFLAGS="-L/opt/homebrew/opt/llvm/lib/c++ -Wl,-rpath,/opt/homebrew/opt/llvm/lib/c++ -L/opt/homebrew/opt/llvm/lib"
+  #   export CFLAGS="-I/opt/homebrew/opt/llvm/include"
+  #   export CPPFLAGS="-I/opt/homebrew/opt/llvm/include"
+  #   export CXXFLAGS="-I/opt/homebrew/opt/llvm/include"
+  #   export CC=`which clang`
+  #   export CXX=`which clang`
+  if (NOT CMAKE_C_COMPILER_ID MATCHES "Clang")
+    message(FATAL_ERROR "LLVM's libfuzzer requires Clang")
+  endif ()
+  message(STATUS "Enabling fuzzing via LLVM's libfuzzer")
+  list(APPEND FSANITIZE "fuzzer")
+  list(APPEND EXTRA_SANITIZER_FLAGS "-g") # fuzzing needs debug symbols
+  list(APPEND EXTRA_SANITIZER_FLAGS "-O1") # make fuzzer faster
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION")
+endif ()
+
+if (ENABLE_ASAN OR ENABLE_MSAN OR ENABLE_UBSAN OR ENABLE_FUZZER)
   string(REPLACE ";" "," FSANITIZE_STR "${FSANITIZE}")
   add_compile_options(-fsanitize=${FSANITIZE_STR} ${EXTRA_SANITIZER_FLAGS})
   add_link_options(-fsanitize=${FSANITIZE_STR})
@@ -81,7 +107,7 @@ if (ENABLE_COVERAGE)
     # globally, as using a 3rd party clang for everything can break your system, so just do
     # it in a single shell - consider writing a script which does this.
     # On my machine this looks like:
-    #   export PATH="/opt/homebrew/opt/llvm/bin:/opt/homebrew/opt/libiconv/bin:$PATH"
+    #   export PATH="/opt/homebrew/opt/llvm/bin:$PATH"
     #   export LDFLAGS="-L/opt/homebrew/opt/llvm/lib/c++ -Wl,-rpath,/opt/homebrew/opt/llvm/lib/c++ -L/opt/homebrew/opt/llvm/lib"
     #   export CFLAGS="-I/opt/homebrew/opt/llvm/include"
     #   export CPPFLAGS="-I/opt/homebrew/opt/llvm/include"
@@ -233,16 +259,18 @@ else ()
 
 endif ()
 
-if ($ENV{TARGET} MATCHES "fuzz")
+if (ENABLE_FUZZER)
   list(APPEND main_SRC "src/fuzz.c")
+  set(BINARY_NAME subzero_fuzzer)
 else ()
   list(APPEND main_SRC "src/main.c")
+  set(BINARY_NAME subzero)
 endif ()
 
-add_executable(subzero ${main_SRC})
+add_executable(${BINARY_NAME} ${main_SRC})
 
 if ($ENV{TARGET} MATCHES "nCipher")
-  target_link_libraries(subzero TrezorCrypto SubzeroProtos)
+  target_link_libraries(${BINARY_NAME} TrezorCrypto SubzeroProtos)
 else()
-  target_link_libraries(subzero TrezorCrypto SubzeroProtos aes_gcm_dev GladmanGCM)
+  target_link_libraries(${BINARY_NAME} TrezorCrypto SubzeroProtos aes_gcm_dev GladmanGCM)
 endif ()

--- a/core/include/log.h
+++ b/core/include/log.h
@@ -5,7 +5,23 @@
 // Part 2/2 of magic to drop the full path from __FILE__
 #define __FILENAME__ (&__FILE__[SOURCE_PATH_SIZE])
 
-#ifdef BTC_TESTNET
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+  // When fuzzing, suppress all log output
+  #define ENABLE_INFO_AND_ERROR_LOGGING 0
+  #define ENABLE_DEBUG_LOGGING 0
+#else
+  // When not fuzzing, always output INFO and ERROR logs
+  #define ENABLE_INFO_AND_ERROR_LOGGING 1
+
+  // When not fuzzing, output DEBUG logs if built with BTC_TESTNET
+  #ifdef BTC_TESTNET
+    #define ENABLE_DEBUG_LOGGING 1
+  #else // must be BTC_MAINNET
+    #define ENABLE_DEBUG_LOGGING 0
+  #endif
+#endif
+
+#if ENABLE_DEBUG_LOGGING == 1
   // Print DEBUG to stdout in cyan
   #define DEBUG(...)                                                           \
     do {                                                                       \
@@ -21,26 +37,34 @@
       printf(__VA_ARGS__);                                                     \
       printf("\033[0m");                                                       \
     } while (0)
-
 #else
-  #define DEBUG(...) do {snprintf(NULL, 0, __VA_ARGS__);} while(0)
-  #define DEBUG_(...) do {snprintf(NULL, 0, __VA_ARGS__);} while(0)
+  #define DEBUG(...) do { snprintf(NULL, 0, __VA_ARGS__); } while(0)
+  #define DEBUG_(...) do { snprintf(NULL, 0, __VA_ARGS__); } while(0)
 #endif
 
-// Print INFO to stdout in green
-#define INFO(...)                                                              \
-  do {                                                                         \
-    printf("\033[0;32m");                                                      \
-    printf("[INFO] %s:%d ", __FILENAME__, __LINE__);                           \
-    printf(__VA_ARGS__);                                                       \
-    printf("\033[0m\n");                                                       \
-  } while (0)
+#if ENABLE_INFO_AND_ERROR_LOGGING == 1
+  // Print INFO to stdout in green
+  #define INFO(...)                                                              \
+    do {                                                                         \
+      printf("\033[0;32m");                                                      \
+      printf("[INFO] %s:%d ", __FILENAME__, __LINE__);                           \
+      printf(__VA_ARGS__);                                                       \
+      printf("\033[0m\n");                                                       \
+    } while (0)
 
-// Print ERROR to stdout in red
-#define ERROR(...)                                                             \
-  do {                                                                         \
-    printf("\033[0;31m");                                                      \
-    printf("[ERROR] %s:%d ", __FILENAME__, __LINE__);                          \
-    printf(__VA_ARGS__);                                                       \
-    printf("\033[0m\n");                                                       \
-  } while (0)
+  // Print ERROR to stdout in red
+  #define ERROR(...)                                                             \
+    do {                                                                         \
+      printf("\033[0;31m");                                                      \
+      printf("[ERROR] %s:%d ", __FILENAME__, __LINE__);                          \
+      printf(__VA_ARGS__);                                                       \
+      printf("\033[0m\n");                                                       \
+    } while (0)
+#else
+  #define INFO(...) do { snprintf(NULL, 0, __VA_ARGS__); } while(0)
+  #define ERROR(...) do { snprintf(NULL, 0, __VA_ARGS__); } while(0)
+#endif
+
+#undef ENABLE_DEBUG_LOGGING
+#undef ENABLE_INFO_LOGGING
+#undef ENABLE_ERROR_LOGGING

--- a/core/src/fuzz.c
+++ b/core/src/fuzz.c
@@ -10,57 +10,15 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-/* This is useful for debugging the fuzz driver. from nanopb docs. */
-static bool fwrite_callback(pb_ostream_t *stream, const uint8_t *buf, size_t count) {
-   FILE *file = (FILE*) stream->state;
-   return fwrite(buf, 1, count, file) == count;
-}
+extern int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
 
-/**
- * Entry point for AFL fuzzing
- * It takes a single argument: A file to read with an InternalCommandRequest
- * protobuf.  It does not write the output anywhere.
- */
-int main(int argc, char **argv) {
-  if (argc != 2) {
-    printf("usage: fuzz <input>\n");
-    return -1;
-  }
+static uint8_t response_buf[4096] = { 0 };
 
-  int fd = open(argv[1], O_RDONLY);
-  if (fd < 0) {
-    printf("open %s failed: %s\n", argv[1], strerror(errno));
-    return -2;
-  }
-
-  struct stat s;
-  if (fstat(fd, &s) < 0) {
-    printf("stat %s failed: %s\n", argv[1], strerror(errno));
-    return -3;
-  }
-
-  void* buf = malloc(s.st_size);
-  if(buf == NULL) {
-    printf("malloc %lld bytes failed\n", s.st_size);
-    return -4;
-  }
-
-  ssize_t count = read(fd, buf, s.st_size);
-  if(count != s.st_size) {
-    printf("Failed to read full amount: %zd is not expected %lld\n", count, s.st_size);
-    return -5;
-  }
-
-  pb_istream_t istream = pb_istream_from_buffer(buf, s.st_size);
-
-  /* Callback may be null to drop the output */
-  //pb_ostream_t ostream = {0, 0, SIZE_MAX, 0, 0};
-
-  pb_ostream_t ostream = {&fwrite_callback, stderr, SIZE_MAX, 0, 0};
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  pb_istream_t istream = pb_istream_from_buffer(data, size);
+  pb_ostream_t ostream = pb_ostream_from_buffer(response_buf, sizeof(response_buf));
 
   handle_incoming_message(&istream, &ostream);
 
-  printf("output size %zu\n", ostream.bytes_written);
-
-  return 0;
+  return 0;  // Values other than 0 and -1 are reserved for future use.
 }

--- a/core/src/protect.c
+++ b/core/src/protect.c
@@ -12,7 +12,9 @@ Result protect_pubkey(char xpub[static XPUB_SIZE],
                       EncryptedPubKey *encrypted_pub_key) {
   // Insert magic string for binary static analysis.
   // This is extremely hacky, but works. ¯\_(ツ)_/¯
+#ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
   printf(MAGIC);
+#endif
 
   if (NULL == encrypted_pub_key) {
     ERROR("%s: null encrypted_pub_key input", __func__);

--- a/docs/fuzz_testing.md
+++ b/docs/fuzz_testing.md
@@ -1,0 +1,126 @@
+# Fuzz testing
+
+Subzero without HSMs can be fuzz-tested with [LLVM's libfuzzer](https://llvm.org/docs/LibFuzzer.html).
+
+First, follow the instructions [here](./running_without_hsm.md) and set up your HSM-less Subzero developer environment.
+If you are on MacOS, you will also have to install the full LLVM toolchain, because Apple's Clang doesn't include libfuzzer.
+For linux users, the following is not necessary and simply installing llvm from your package manager should suffice.
+
+## Install the full LLVM toolchain with Homebrew (MacOS only)
+
+    # Install the full LLVM toolchain
+    brew install llvm
+
+    # Heed the warning from Homebrew and copy it somewhere - it tells you how to manipulate your environment
+    # to use the Homebrew-installed Clang, which will not take precedence over Apple's Clang by default.
+    # On my machine, it looks something like this:
+    # export PATH="/opt/homebrew/opt/llvm/bin:$PATH"
+    # export LDFLAGS="-L/opt/homebrew/opt/llvm/lib/c++ -Wl,-rpath,/opt/homebrew/opt/llvm/lib/c++ -L/opt/homebrew/opt/llvm/lib"
+    # export CPPFLAGS="-I/opt/homebrew/opt/llvm/include"
+    # export CXXFLAGS="-I/opt/homebrew/opt/llvm/include"
+    # export CFLAGS="-I/opt/homebrew/opt/llvm/include"
+    # export CC=`which clang`
+    # export CXX=`which clang`
+
+    # It's not a bad idea to put the above into a script that you can source on demand when needed:
+    touch ~/use-brew-llvm.sh
+    echo 'export PATH="/opt/homebrew/opt/llvm/bin:$PATH"' >> ~/use-brew-llvm.sh
+    echo 'export LDFLAGS="-L/opt/homebrew/opt/llvm/lib/c++ -Wl,-rpath,/opt/homebrew/opt/llvm/lib/c++ -L/opt/homebrew/opt/llvm/lib"' >> ~/use-brew-llvm.sh
+    echo 'export CPPFLAGS="-I/opt/homebrew/opt/llvm/include"' >> ~/use-brew-llvm.sh
+    echo 'export CXXFLAGS="-I/opt/homebrew/opt/llvm/include"' >> ~/use-brew-llvm.sh
+    echo 'export CFLAGS="-I/opt/homebrew/opt/llvm/include"' >> ~/use-brew-llvm.sh
+    echo 'export CC=`which clang`' >> ~/use-brew-llvm.sh
+    echo 'export CXX=`which clang`' >> ~/use-brew-llvm.sh
+
+    # Now you can enable Homebrew Clang with a simple command:
+    source ~/use-brew-llvm.sh
+
+    # You can check that it worked by running the following command. You should see "Homebrew clang" rather than "Apple clang" in the first line of output:
+    clang --version
+
+## Generate the initial corpus
+
+Fuzzing will go much better if you provide the fuzzer with an initial set of inputs to start from. Let's generate them now.
+For this, you will need a standard subzero core binary and the java GUI.
+
+    # Build and run subzero core in Terminal 1
+    cd core
+    mkdir build
+    cd build
+    TARGET=dev CURRENCY=btc-testnet cmake ../
+    make
+    ./subzero
+
+    # Build the GUI and use it to generate the inital corpus in Terminal 2
+    # You will need an empty wallet directory for the generate-wallets test.
+    # You will also need an output directory for the initial fuzzer corpus.
+    cd java
+    mkdir fuzzing_corpus
+    mkdir wallets
+    touch wallets/.subzero_702e63a9
+    ./gradlew build
+
+    # Run the generate wallet files test, writing the internal requests into the corpus directory
+    # This will prompt you to type "yes" + Enter 8 times, then it will hang waiting for more input. Ctrl-C when done.
+    java -jar gui/build/libs/gui-1.0.0-SNAPSHOT-shaded.jar --generate-wallet-files-test --wallet-dir wallets --generate-fuzzing-corpus --fuzzing-corpus-output-dir fuzzing_corpus
+
+    # Check our work ... this should output "8" because we just wrote 8 internal request files into the corpus
+    ls -1 fuzzing_corpus | wc -l
+
+    # Run the signtx test, writing the internal requests into the corpus directory.
+    # This might take a couple minutes
+    java -jar gui/build/libs/gui-1.0.0-SNAPSHOT-shaded.jar --signtx-test --generate-fuzzing-corpus --fuzzing-corpus-output-dir fuzzing_corpus
+
+    # Check our work again ... this should output "265" because we just wrote 257 more internal request files into the corpus
+    ls -1 fuzzing_corpus | wc -l
+
+    # Go back to Terminal 1 and ctrl-C the subzero process. We're done with it for now.
+
+## Build the fuzzer binary
+
+Now that we have generated the initial corpus, we can build the fuzzer binary and do some fuzzing.
+
+    # Build the fuzzer binary. We want to fuzz with ASAN + UBSAN enabled, since that will catch more bugs.
+    cd core
+    mkdir -p build
+    cd build
+    TARGET=dev CURRENCY=btc-testnet cmake ../ -DENABLE_ASAN=ON -DENABLE_UBSAN=ON -DENABLE_FUZZER=ON
+    make
+
+## Minimize the initial corpus
+
+Many of the inputs in our initial corpus trigger the exact same code paths, therefore they are redundant and not very useful.
+We can minimize the initial corpus before kicking off the real fuzz test. Here is how to do that.
+
+    # Create an output directory for the minimized corpus
+    cd core
+    mkdir fuzzing_corpus
+
+    # Run the fuzzer once with -merge=1 to produce a minimized corpus. This will take a bit of time.
+    build/subzero_fuzzer -merge=1 fuzzing_corpus ../java/fuzzing_corpus
+
+## Run the fuzz test
+
+Now we are finally ready to run the fuzz test! Here we go:
+
+    # Fuzz test some code paths. Leave this running for a while, then check the directory for crash-* files.
+    # If any are generated, those are the inputs which caused a crash.
+    # To stop the fuzzer, ctrl-Z then run 'kill -9 %1'
+    build/subzero_fuzzer -forks=10 -workers=10 -jobs=10 -ignore_ooms=1 -ignore_timeouts=1 -ignore_crashes=1 fuzzing_corpus
+
+## Reproducing a failure
+
+If any crashes / ooms / timeouts / etc were found, libfuzzer will generate corresponding fuzz output files outside the corpus,
+in the directory from which the fuzzer was run (i.e. subzero/core). You can run the fuzzer with a single input to reproduce the crash.
+If a crash is found, it's probably a good idea to fix it and save the bad input for a future regression test.
+
+    # Running the fuzzer with a single bad crash input
+    build/subzero_fuzzer crash-017668d340dca49646f38fab6c044145fbfadb76
+    # Crash output follows
+
+## A note on logic changes when fuzz testing
+
+When you build the fuzz-test binary, there are a few logic changes from a production build:
+- All logging output is disabled
+- Invalid QR code signatures are ignored
+- AES-GCM decryption failures are ignored

--- a/java/.gitignore
+++ b/java/.gitignore
@@ -24,3 +24,6 @@ gradle-app.setting
 
 # Maven output directory. For some reason our gradle build still puts a few things there.
 **/target/
+
+# Ignore fuzzing corpus output directory
+fuzzing_corpus

--- a/java/gui/src/main/java/com/squareup/subzero/InternalCommandConnector.java
+++ b/java/gui/src/main/java/com/squareup/subzero/InternalCommandConnector.java
@@ -2,12 +2,15 @@ package com.squareup.subzero;
 
 import com.squareup.subzero.exceptions.HsmConnectionException;
 import com.squareup.subzero.exceptions.MismatchedVersionException;
-import com.squareup.subzero.exceptions.SelfCheckException;
 import com.squareup.subzero.exceptions.UnknownException;
+import com.squareup.subzero.observers.InternalCommandRequestObserver;
+import com.squareup.subzero.observers.NoopObserver;
 import com.squareup.subzero.proto.service.Internal.InternalCommandRequest;
 import com.squareup.subzero.proto.service.Internal.InternalCommandResponse;
+
 import java.io.IOException;
 import java.net.Socket;
+import java.util.Objects;
 
 /**
  * InternalCommandConnection is a connection, usually over localhost, to the C server portion
@@ -16,24 +19,36 @@ import java.net.Socket;
 public class InternalCommandConnector {
   private String host;
   private int port;
+  private final InternalCommandRequestObserver observer;
 
   /**
    * The default constructor is hardcoded to make connections to localhost:32366, which is the
    * port assigned to us in Registry.
    */
   public InternalCommandConnector() {
-    this("localhost", 32366);
+    this("localhost", 32366, new NoopObserver());
   }
 
   public InternalCommandConnector(String host, int port) {
-    this.host = host;
+    this(host, port, new NoopObserver());
+  }
+
+  public InternalCommandConnector(String host, int port, final InternalCommandRequestObserver observer) {
+    this.host = Objects.requireNonNull(host);
     this.port = port;
+    this.observer = Objects.requireNonNull(observer);
   }
 
   /**
    * Run a command.  Opens a connection, writes the request, reads the response, and returns it
    */
   public InternalCommandResponse run(InternalCommandRequest internalRequest) {
+    try {
+      observer.observe(internalRequest);
+    } catch (Exception e) {
+      System.out.println("Error from InternalCommandRequestObserver: " + e);
+    }
+
     Socket socket;
     try {
       socket = new Socket(this.host, this.port);

--- a/java/gui/src/main/java/com/squareup/subzero/observers/CreateFuzzerCorpusObserver.java
+++ b/java/gui/src/main/java/com/squareup/subzero/observers/CreateFuzzerCorpusObserver.java
@@ -1,0 +1,56 @@
+package com.squareup.subzero.observers;
+
+import com.squareup.subzero.proto.service.Internal;
+
+import java.io.ByteArrayOutputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+/**
+ * <p>Interface for an observer that writes each
+ * {@link com.squareup.subzero.proto.service.Internal.InternalCommandRequest} as a separate file to an output directory,
+ * before the request is sent to Subzero Core by {@link com.squareup.subzero.InternalCommandConnector}.</p>
+ *
+ * <p>This is used together with the --signtx-test and --generate-wallet-files-test options to build an initial
+ * LLVM libfuzzer corpus.</p>
+ *
+ * <p>Each file is named as the hex-encoded SHA-1 hash of its contents, which is the same naming convention that
+ * LLVM's libfuzzer itself uses for naming novel inputs as they are discovered.</p>
+ */
+public class CreateFuzzerCorpusObserver implements InternalCommandRequestObserver {
+    private final Path outputDir;
+
+    public CreateFuzzerCorpusObserver(final Path outputDir) {
+        this.outputDir = outputDir;
+    }
+
+    @Override
+    public void observe(Internal.InternalCommandRequest internalRequest) {
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            internalRequest.writeDelimitedTo(baos);
+            byte[] serializedRequest = baos.toByteArray();
+            // LLVM's libfuzzer names each file as sha1(file contents).
+            // Let's do the same when seeding the initial corpus.
+            String sha1hex = sha1(serializedRequest);
+            FileOutputStream output = new FileOutputStream(outputDir.resolve(sha1hex).toFile());
+            output.write(serializedRequest);
+            output.close();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String sha1(byte[] data) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-1");
+            byte[] hash = md.digest(data);
+            return org.bitcoinj.core.Utils.HEX.encode(hash);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/java/gui/src/main/java/com/squareup/subzero/observers/InternalCommandRequestObserver.java
+++ b/java/gui/src/main/java/com/squareup/subzero/observers/InternalCommandRequestObserver.java
@@ -1,0 +1,13 @@
+package com.squareup.subzero.observers;
+
+import com.squareup.subzero.proto.service.Internal.InternalCommandRequest;
+
+/**
+ * Interface for an observer that takes some action on an
+ * {@link com.squareup.subzero.proto.service.Internal.InternalCommandRequest} before it's sent to Subzero Core
+ * by {@link com.squareup.subzero.InternalCommandConnector}. The actions are allowed to have side effects, such as
+ * writing to a file.
+ */
+public interface InternalCommandRequestObserver {
+    void observe(InternalCommandRequest internalRequest);
+}

--- a/java/gui/src/main/java/com/squareup/subzero/observers/NoopObserver.java
+++ b/java/gui/src/main/java/com/squareup/subzero/observers/NoopObserver.java
@@ -1,0 +1,14 @@
+package com.squareup.subzero.observers;
+
+import com.squareup.subzero.proto.service.Internal;
+
+/**
+ * An {@link InternalCommandRequestObserver} which does nothing. This is the default observer in
+ * {@link com.squareup.subzero.InternalCommandConnector}.
+ */
+public class NoopObserver implements InternalCommandRequestObserver {
+    @Override
+    public void observe(Internal.InternalCommandRequest internalRequest) {
+        // Do nothing
+    }
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,7 @@ nav:
       - Running the code without HSMs: running_without_hsm.md
       - Developing with a remote HSM: dev_with_remote_hsm.md
       - Transaction signing regression test: regression-testing-howto.md
+      - Fuzz testing: fuzz_testing.md
     - Initialization:
       - HSM initialization: hsm_initialization.md
       - Wallet initialization: wallet_initialization.md


### PR DESCRIPTION
Rewrite the bit-rotted fuzzing code. Summary of changes:
1. Fuzzing is now enabled similar to sanitizers, with -DENABLE_FUZZER=ON parameter to cmake
2. When fuzzing is enabled, the output binary is `subzero_fuzzer` rather than `subzero`.
3. When fuzzing is enabled, all log output is suppressed, per recommendation from libfuzzer docs.
4. When fuzzing is enabled, debug symbols are included, per recommendation from libfuzzer docs.
5. When fuzzing is enabled, -O1 optimization level is used, per recommendation from libfuzzer docs.
6. When fuzzing is enabled, QR signature check failures are ignored, so we can fuzz the post-signature-check code paths.
7. When fuzzing is enabled, ignore AES-GCM decryption errors, so we can fuzz the post-decryption code paths.
8. Added new options --generate-fuzzing-corpus and --fuzzing-corpus-output-dir to the GUI. These can be used to generate an initial fuzzing corpus (together with --signtx-test and --generate-wallet-files-test).
9. Fixed a bug with --generate-wallet-files-test - it needs to initialize screens in order to work.
10. Added a new fuzz testing section to documentation page.

Potential future work:
- use google's libprotobuf-mutator for structure-aware fuzzing