### PR TITLE
[java] remove unnecessary synchronized block in Base45.indexOf()

### DIFF
--- a/java/shared/src/main/java/com/squareup/subzero/shared/Base45.java
+++ b/java/shared/src/main/java/com/squareup/subzero/shared/Base45.java
@@ -23,9 +23,20 @@ import static java.lang.String.format;
 public final class Base45 {
   /** The ordered set of valid Base45 characters as a String. */
   protected static final String CHARSET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ $%*+-./:";
-  private final static Object lock = new Object();
   /** The reverse-lookup map from Base45 character to Integer value. */
-  protected static ImmutableMap<Character, Integer> REVERSE_CHARSET = null;
+  protected static final ImmutableMap<Character, Integer> REVERSE_CHARSET = makeReverseCharset();
+
+  /**
+   * Constructs the reverse-lookup character-to-integer map.
+   * @return the reverse-lookup character-to-integer map.
+   */
+  private static ImmutableMap<Character, Integer> makeReverseCharset() {
+    HashMap<Character, Integer> map = new HashMap<>(CHARSET.length());
+    for (int i = 0; i < CHARSET.length(); i++) {
+      map.put(CHARSET.charAt(i), i);
+    }
+    return ImmutableMap.copyOf(map);
+  }
 
   /** Everything in this class is static, so don't allow construction. */
   private Base45() {}
@@ -37,16 +48,6 @@ public final class Base45 {
    *         not a member of the Base45 charset.
    */
   protected static Integer indexOf(char c) {
-    // The map needs to be initialized in a thread-safe way.
-    synchronized (lock) {
-      if (REVERSE_CHARSET == null) {
-        HashMap<Character, Integer> map = new HashMap<>(45);
-        for (int i = 0; i < 45; i++) {
-          map.put(CHARSET.charAt(i), i);
-        }
-        REVERSE_CHARSET = ImmutableMap.copyOf(map);
-      }
-    }
     return REVERSE_CHARSET.get(c);
   }
 

--- a/java/shared/src/test/java/com/squareup/subzero/shared/Base45Test.java
+++ b/java/shared/src/test/java/com/squareup/subzero/shared/Base45Test.java
@@ -80,4 +80,10 @@ public class Base45Test {
   public void testInvalidBase45() {
     Base45.fromBase45("foobar");
   }
+
+  @Test
+  public void testKnownValue() {
+    byte[] buf = new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+    assertEquals("0010BK0M*0YD10W", Base45.toBase45(buf));
+  }
 }


### PR DESCRIPTION
We can initialize the static REVERSE_CHARSET map when the class is loaded and remove the lock.