### PR TITLE
Update nanopb submodule to release 0.4.5.

### DIFF
--- a/core/proto/CMakeLists.txt
+++ b/core/proto/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../nanopb/extra/)
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/../nanopb/extra/)
 find_package(Nanopb REQUIRED)
 include_directories(${NANOPB_INCLUDE_DIRS})
 
@@ -8,9 +8,11 @@ set(protos
     "${CMAKE_CURRENT_LIST_DIR}/squareup/subzero/service.proto"
 )
 
+# The next 2 lines are needed to build with nanopb 0.4.5. Can be removed if we update to 0.4.7.
+set(NANOPB_GENERATE_CPP_APPEND_PATH FALSE)
+set(NANOPB_OPTIONS "-I${CMAKE_CURRENT_LIST_DIR}/")
 nanopb_generate_cpp(PROTO_SRCS PROTO_HDRS ${protos} RELPATH ${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
-#add_custom_target(generate_proto_sources DEPENDS ${PROTO_SRCS} ${PROTO_HDRS})
 set_source_files_properties(${PROTO_SRCS} ${PROTO_HDRS}
     PROPERTIES GENERATED TRUE)
 

--- a/core/src/rpc.c
+++ b/core/src/rpc.c
@@ -51,7 +51,7 @@ static Result populate_internal_command(InternalCommandRequest * to){
   CommandRequest from = CommandRequest_init_default;
   // Cannot use pb_decode_delimited as on the coordinator service the java code is generating bytes
   // without the delimited values.
-  if(!pb_decode(&pb_command, CommandRequest_fields, &from)){
+  if (!pb_decode(&pb_command, &CommandRequest_msg, &from)) {
     res = Result_COMMAND_DECODE_FAILED;
     ERROR("Could not decode input bytes for command request.");
     goto cleanup;
@@ -96,7 +96,7 @@ static void handle_error(pb_istream_t * input, pb_ostream_t * output, Result err
   snprintf(out.response.Error.message, sizeof(out.response.Error.message),
             "%s: %s", error_message, PB_GET_ERROR(input));
   out.response.Error.has_message = true;
-  if (!pb_encode_delimited(output, InternalCommandResponse_fields, &out)) {
+  if (!pb_encode_delimited(output, &InternalCommandResponse_msg, &out)) {
     ERROR("Encoding error message about decoding failed: %s",
           PB_GET_ERROR(output));
   }
@@ -108,7 +108,7 @@ void handle_incoming_message(pb_istream_t *input, pb_ostream_t *output) {
   InternalCommandRequest cmd = InternalCommandRequest_init_default;
   InternalCommandResponse out = InternalCommandResponse_init_default;
 
-  if (!pb_decode_delimited(input, InternalCommandRequest_fields, &cmd)) {
+  if (!pb_decode_delimited(input, &InternalCommandRequest_msg, &cmd)) {
     handle_error(input, output, Result_COMMAND_DECODE_FAILED, "Decode Input failed");
     return;
   }
@@ -126,7 +126,7 @@ void handle_incoming_message(pb_istream_t *input, pb_ostream_t *output) {
   }
   execute_command(&cmd, &out);
 
-  if (!pb_encode_delimited(output, InternalCommandResponse_fields, &out)) {
+  if (!pb_encode_delimited(output, &InternalCommandResponse_msg, &out)) {
     handle_error(input, output, Result_COMMAND_ENCODE_FAILED, "Encoding failed");
     return;
   }


### PR DESCRIPTION
This replaces #577, we decided to update to 0.4.5 instead because it's the version used by trezor so we trust it a bit more.

Had to make some minor changes to how we configure our nanopb in CMakeLists.txt.