### PR TITLE
Split the SignTx test github action into 4 separate actions

### DIFF
--- a/.github/workflows/signtx-test-asan.yml
+++ b/.github/workflows/signtx-test-asan.yml
@@ -1,5 +1,5 @@
 # Subzero regression test for transaction signing
-name: "SignTx Regression Test"
+name: "SignTx Regression Test with ASAN"
 
 on:
   push:
@@ -12,8 +12,8 @@ on:
     - cron: '0 1 * * *'
 
 jobs:
-  signtx-test:
-    name: "SignTx Test"
+  signtx-test-asan:
+    name: "SignTx Test with ASAN"
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -54,19 +54,19 @@ jobs:
         cd ${{ github.workspace }}/java
         ./gradlew clean build --info
 
-    # Build CORE
-    - name: Build Subzero Core
-      run: scripts/build_core.sh
+    # Build CORE with ASAN
+    - name: Build Subzero Core with ASAN
+      run: scripts/build_core.sh -DENABLE_ASAN=ON
 
-    - name: Run Subzero CORE
+    - name: Run Subzero CORE with ASAN
       run: |
         cd ${{ github.workspace }}
         ./core/build/subzero-testnet &
 
-    - name: Run SignTx Test
+    - name: Run SignTx Test with ASAN
       run: |
         cd ${{ github.workspace }}
         sleep 10
-        rm -f /tmp/signtx-test.out
-        java -jar ./java/gui/build/libs/gui-1.0.0-SNAPSHOT-shaded.jar --signtx-test | tee /tmp/signtx-test.out
-        grep -qv "ALL TESTS PASSED" /tmp/signtx-test.out || exit 1
+        rm -f /tmp/signtx-test-asan.out
+        java -jar ./java/gui/build/libs/gui-1.0.0-SNAPSHOT-shaded.jar --signtx-test | tee /tmp/signtx-test-asan.out
+        grep -qv "ALL TESTS PASSED" /tmp/signtx-test-asan.out || exit 1

--- a/.github/workflows/signtx-test-msan.yml
+++ b/.github/workflows/signtx-test-msan.yml
@@ -1,5 +1,5 @@
 # Subzero regression test for transaction signing
-name: "SignTx Regression Test"
+name: "SignTx Regression Test with MSAN"
 
 on:
   push:
@@ -12,8 +12,8 @@ on:
     - cron: '0 1 * * *'
 
 jobs:
-  signtx-test:
-    name: "SignTx Test"
+  signtx-test-msan:
+    name: "SignTx Test with MSAN"
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -54,19 +54,28 @@ jobs:
         cd ${{ github.workspace }}/java
         ./gradlew clean build --info
 
-    # Build CORE
-    - name: Build Subzero Core
-      run: scripts/build_core.sh
+    - name: Setup Clang (for MSAN)
+      uses: egor-tensin/setup-clang@v1.4
+      with:
+        version: latest
+        platform: x64
 
-    - name: Run Subzero CORE
+    # Build CORE with MSAN
+    - name: Build Subzero Core with MSAN
+      run: |
+        export CC=`which clang`
+        export CXX=`which clang++`
+        scripts/build_core.sh -DENABLE_MSAN=ON
+
+    - name: Run Subzero CORE with MSAN
       run: |
         cd ${{ github.workspace }}
         ./core/build/subzero-testnet &
 
-    - name: Run SignTx Test
+    - name: Run SignTx Test with MSAN
       run: |
         cd ${{ github.workspace }}
         sleep 10
-        rm -f /tmp/signtx-test.out
-        java -jar ./java/gui/build/libs/gui-1.0.0-SNAPSHOT-shaded.jar --signtx-test | tee /tmp/signtx-test.out
-        grep -qv "ALL TESTS PASSED" /tmp/signtx-test.out || exit 1
+        rm -f /tmp/signtx-test-msan.out
+        java -jar ./java/gui/build/libs/gui-1.0.0-SNAPSHOT-shaded.jar --signtx-test | tee /tmp/signtx-test-msan.out
+        grep -qv "ALL TESTS PASSED" /tmp/signtx-test-msan.out || exit 1

--- a/.github/workflows/signtx-test-ubsan.yml
+++ b/.github/workflows/signtx-test-ubsan.yml
@@ -1,5 +1,5 @@
 # Subzero regression test for transaction signing
-name: "SignTx Regression Test"
+name: "SignTx Regression Test with UBSAN"
 
 on:
   push:
@@ -12,8 +12,8 @@ on:
     - cron: '0 1 * * *'
 
 jobs:
-  signtx-test:
-    name: "SignTx Test"
+  signtx-test-ubsan:
+    name: "SignTx Test with UBSAN"
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -54,19 +54,19 @@ jobs:
         cd ${{ github.workspace }}/java
         ./gradlew clean build --info
 
-    # Build CORE
-    - name: Build Subzero Core
-      run: scripts/build_core.sh
+    # Build CORE with UBSAN
+    - name: Build Subzero Core with UBSAN
+      run: scripts/build_core.sh -DENABLE_UBSAN=ON
 
-    - name: Run Subzero CORE
+    - name: Run Subzero CORE with UBSAN
       run: |
         cd ${{ github.workspace }}
         ./core/build/subzero-testnet &
 
-    - name: Run SignTx Test
+    - name: Run SignTx Test with UBSAN
       run: |
         cd ${{ github.workspace }}
         sleep 10
-        rm -f /tmp/signtx-test.out
-        java -jar ./java/gui/build/libs/gui-1.0.0-SNAPSHOT-shaded.jar --signtx-test | tee /tmp/signtx-test.out
-        grep -qv "ALL TESTS PASSED" /tmp/signtx-test.out || exit 1
+        rm -f /tmp/signtx-test-ubsan.out
+        java -jar ./java/gui/build/libs/gui-1.0.0-SNAPSHOT-shaded.jar --signtx-test | tee /tmp/signtx-test-ubsan.out
+        grep -qv "ALL TESTS PASSED" /tmp/signtx-test-ubsan.out || exit 1


### PR DESCRIPTION
Now we have 4 separate actions:
- unsanitized build
- ASAN build
- UBSAN build
- MSAN build

This has two benefits. First, if an action fails it will be more clear if it failed due to a particular sanitizer. Second, the actions should finish faster after a PR is submitted due to parallelism.