### PR TITLE
[java] don't echo the ACS password when running the --init-nvram command

### DIFF
--- a/java/gui/src/main/java/com/squareup/subzero/framebuffer/Framebuffer.java
+++ b/java/gui/src/main/java/com/squareup/subzero/framebuffer/Framebuffer.java
@@ -283,6 +283,10 @@ public class Framebuffer {
    * @throws IOException From reading input
    */
   public String prompt(int size, int yOffset, boolean password) throws IOException {
+    if (password) {
+      this.flip(); // draw prompt to the framebuffer
+      return new String(System.console().readPassword());
+    }
     String input = "";
     BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
     while(true) {
@@ -320,12 +324,7 @@ public class Framebuffer {
       }
 
       String output;
-      if (password) {
-        // Don't display passwords.  Stars instead.
-        output = Strings.repeat("*", input.length());
-      } else {
-        output = input;
-      }
+      output = input;
       if (output.length() > 100) {
         ltext("...".concat(output.substring(output.length() - 100)), size, yOffset);
       } else {


### PR DESCRIPTION
I discovered that the ACS password is echoed to the screen when running the GUI with the --init-nvram option. This is obviously bad as anyone present in the room would be able to see the password. Fixed by using System.console().readPassword() instead of reading from System.in.

Tested on my at-home HSM machine, both with and without a framebuffer, works as expected.