### PR TITLE
[core] validate destination enum in handle_sign_tx()

### DIFF
--- a/core/proto/squareup/subzero/internal.proto
+++ b/core/proto/squareup/subzero/internal.proto
@@ -122,6 +122,9 @@ enum Result {
   COMMAND_SHOULD_BE_SIGNTX = 54;
   SERIALIZED_BYTES_SHOULD_BE_PRESENT = 55;
 
+  SIGNTX_ZERO_OUTPUTS = 56;
+  SIGNTX_INVALID_DESTINATION = 57;
+
   // any other error messages, such as INSERT_OCS, incorrect passphrase, etc.
   // 5xx represents failures which user input shouldn't be able to trigger
   UNKNOWN_INTERNAL_FAILURE = 500;

--- a/java/proto/src/main/proto/squareup/subzero/internal.proto
+++ b/java/proto/src/main/proto/squareup/subzero/internal.proto
@@ -114,11 +114,13 @@ enum Result {
   NO_ROLLBACK_INVALID_FORMAT = 49;
   NO_ROLLBACK_INVALID_MAGIC = 50;
   NO_ROLLBACK_INVALID_VERSION = 51;
-
   QRSIG_CHECK_FAILED = 52;
   REQUIRED_FIELDS_NOT_PRESENT = 53;
   COMMAND_SHOULD_BE_SIGNTX = 54;
   SERIALIZED_BYTES_SHOULD_BE_PRESENT = 55;
+
+  SIGNTX_ZERO_OUTPUTS = 56;
+  SIGNTX_INVALID_DESTINATION = 57;
 
   // any other error messages, such as INSERT_OCS, incorrect passphrase, etc.
   // 5xx represents failures which user input shouldn't be able to trigger


### PR DESCRIPTION
The core logic should not assume that the destination field is always one of GATEWAY or CHANGE. Trust but verify.